### PR TITLE
Use convention in position gradients sample labels

### DIFF
--- a/src/equisolve/utils/convert.py
+++ b/src/equisolve/utils/convert.py
@@ -95,11 +95,14 @@ def properties_to_tensormap(
                 f"{gradient_data.shape[1]}"
             )
 
+        # The `"sample"` label refers to the index of the corresponding value in the
+        # block. Here, the number of values is the same as the number of structures so
+        # we can keep `"sample"` and `"structure"` the same.
         position_gradient_samples = Labels(
             ["sample", "structure", "atom"],
             np.array(
                 [
-                    [s + a, s, a]
+                    [s, s, a]
                     for s in range(len(positions_gradients))
                     for a in range(len(positions_gradients[s]))
                 ]

--- a/tests/utils/test_convert.py
+++ b/tests/utils/test_convert.py
@@ -38,7 +38,6 @@ class TestConvert:
         return [i for i in self.rng.random([self.n_strucs, 3, 3])]
 
     def test_ase_to_tensormap(self, energies, forces, stress):
-
         frames = []
         for i in range(len(energies)):
             frame = ase.Atoms(self.n_atoms * "H")
@@ -49,7 +48,8 @@ class TestConvert:
 
         property_tm = ase_to_tensormap(frames, "energy", "forces", "stress")
 
-        # Use block() dunction to check that TensorMap only has one block.
+        # Use `block()` function without parameters to check that TensorMap
+        # only has one block.
         block = property_tm.block()
 
         assert_equal(block.values, np.array(energies).reshape(-1, 1))
@@ -62,7 +62,6 @@ class TestConvert:
         )
 
     def test_properties_to_tensormap(self, energies, forces, stress):
-
         property_tm = properties_to_tensormap(energies, forces, stress)
         block = property_tm.block()
 
@@ -72,3 +71,31 @@ class TestConvert:
             np.concatenate(forces, axis=0).reshape(-1, 3, 1),
         )
         assert_equal(block.gradient("cell").data, np.array(stress).reshape(-1, 3, 3, 1))
+
+    def test_position_gradient_samples(self, energies, forces):
+        """Test that the position gradients sample labels agree with the convention."""
+
+        property_tm = properties_to_tensormap(energies, forces)
+        block = property_tm.block()
+
+        samples = block.gradient("positions").samples
+
+        assert samples.names == (
+            "sample",
+            "structure",
+            "atom",
+        )
+
+        assert_equal(
+            samples.tolist(),
+            [
+                (0, 0, 0),
+                (0, 0, 1),
+                (0, 0, 2),
+                (0, 0, 3),
+                (1, 1, 0),
+                (1, 1, 1),
+                (1, 1, 2),
+                (1, 1, 3),
+            ],
+        )


### PR DESCRIPTION
As @Luthaf already pointed out in a [comment](https://github.com/lab-cosmo/equisolve/pull/3#discussion_r1043208291) in #3: The convention for the position gradients sample labels is a bit different as we defined it here. This PR changes the `properties_to_tensormap` functiom to use the same convention.