### PR TITLE
Add tests for StandardScaler covering with_mean and with_std

### DIFF
--- a/src/equisolve/numpy/preprocessing/_base.py
+++ b/src/equisolve/numpy/preprocessing/_base.py
@@ -16,7 +16,9 @@ class StandardScaler:
         ``"cell"`` or a combination of these.
     :param with_mean:
         If ``True``, center the data before scaling. If ``False``,
-        keep the mean intact
+        keep the mean intact. Because all operations are consistent
+        wrt. to the derivative, the mean is only taken from the values,
+        but not from the gradients, since ∇(X - mean) = ∇X
     :param with_std:
         If ``True``, scale the data to unit variance. If ``False``,
         keep the variance intact
@@ -90,24 +92,15 @@ class StandardScaler:
                 components=[],
                 properties=Labels.single(),
             )
-            n_properties_block = TensorBlock(
-                values=np.array([len(X_block.properties)], dtype=np.int32).reshape(
-                    1, 1
-                ),
-                samples=Labels.single(),
-                components=[],
-                properties=Labels.single(),
-            )
+
         # TODO use this in transform function to do a check
         self.n_components_ = TensorMap(X.keys, [n_components_block])
-        self.n_properties_ = TensorMap(X.keys, [n_properties_block])
+        self.n_properties_ = len(X_block.properties)
 
         mean_blocks = []
         scale_blocks = []
 
-        # this is how it will look like when we replace with equistore oprations
-        # if self.with_mean:
-        #    self.mean_ = equistore.operations.mean_over_samples(X, X.samples_names)
+        # replace with equistore oprations see issue #18
         for key, X_block in X:
             # if values not in parameter_keys, we create empty tensor block to
             # attach gradients
@@ -121,9 +114,7 @@ class StandardScaler:
                 if self.with_mean:
                     mean_values = np.average(X_mat, weights=sample_weights, axis=0)
                 else:
-                    mean_values = np.zeros(
-                        self.n_properties_.block(key).values.flatten()
-                    )
+                    mean_values = np.zeros(self.n_properties_)
 
                 mean_block = TensorBlock(
                     values=mean_values.reshape((1,) + mean_values.shape),
@@ -177,26 +168,18 @@ class StandardScaler:
                     properties=Labels.single(),
                 )
 
-            for parameter in self.parameter_keys:
-                if parameter == "values":
-                    continue
-
+            for parameter in X_block.gradients_list():
                 X_mat = block_to_array(X_block, [parameter])
                 # X_gradient = X_block.gradient(parameter)
 
                 if sample_weights is not None:
                     sw_block = sample_weights.block(key)
                     sample_weights = block_to_array(sw_block, [parameter])
-                if self.with_mean:
+                if self.with_mean and (parameter in self.parameter_keys):
                     mean_values = np.average(X_mat, weights=sample_weights, axis=0)
                     mean_values = mean_values.reshape((1, 1) + mean_values.shape)
                 else:
-                    n_properties = (
-                        self.n_properties_.block(key)
-                        .gradient(parameter)
-                        .data.flatten()[0]
-                    )
-                    mean_values = np.zeros((1, 1, n_properties))
+                    mean_values = np.zeros((1, 1, self.n_properties_))
 
                 mean_block.add_gradient(
                     parameter,
@@ -205,7 +188,7 @@ class StandardScaler:
                     [Labels.single()],
                 )
 
-                if self.with_std:
+                if self.with_std and (parameter in self.parameter_keys):
                     X_mean = np.average(X_mat, weights=sample_weights, axis=0)
                     var = np.average((X_mat - X_mean) ** 2, axis=0)
 
@@ -279,9 +262,7 @@ class StandardScaler:
                 properties=X_block.properties,
             )
 
-            for parameter in self.parameter_keys:
-                if parameter == "values":
-                    continue
+            for parameter in X_block.gradients_list():
                 X_gradient = X_block.gradient(parameter)
 
                 block.add_gradient(
@@ -331,9 +312,7 @@ class StandardScaler:
                 properties=X_block.properties,
             )
 
-            for parameter in self.parameter_keys:
-                if parameter == "values":
-                    continue
+            for parameter in X_block.gradients_list():
                 X_gradient = X_block.gradient(parameter)
 
                 block.add_gradient(

--- a/tests/equisolve_tests/numpy/utils.py
+++ b/tests/equisolve_tests/numpy/utils.py
@@ -1,0 +1,55 @@
+import numpy as np
+from equistore import Labels, TensorBlock, TensorMap
+
+
+def random_single_block_no_components_tensor_map():
+    """
+    Create a dummy tensor map to be used in tests. This is the same one as the
+    tensor map used in `tensor.rs` tests.
+    """
+    block_1 = TensorBlock(
+        values=np.random.rand(4, 2),
+        samples=Labels(
+            ["sample", "structure"],
+            np.array([[0, 0], [1, 1], [2, 2], [3, 3]], dtype=np.int32),
+        ),
+        components=[],
+        properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
+    )
+    block_1.add_gradient(
+        "positions",
+        data=np.random.rand(7, 3, 2),
+        samples=Labels(
+            ["sample", "structure", "center"],
+            np.array(
+                [
+                    [0, 0, 1],
+                    [0, 0, 2],
+                    [1, 1, 0],
+                    [1, 1, 1],
+                    [1, 1, 2],
+                    [2, 2, 0],
+                    [3, 3, 0],
+                ],
+                dtype=np.int32,
+            ),
+        ),
+        components=[Labels(["direction"], np.array([[0], [1], [2]], dtype=np.int32))],
+    )
+
+    block_1.add_gradient(
+        "cell",
+        data=np.random.rand(4, 6, 2),
+        samples=Labels(
+            ["sample", "structure"],
+            np.array([[0, 0], [1, 1], [2, 2], [3, 3]], dtype=np.int32),
+        ),
+        components=[
+            Labels(
+                ["direction_xx_yy_zz_yz_xz_xy"],
+                np.array([[0], [1], [2], [3], [4], [5]], dtype=np.int32),
+            )
+        ],
+    )
+
+    return TensorMap(Labels.single(), [block_1])


### PR DESCRIPTION
I hope it is clear from the commit messages and title. I can also split it up into two PRs, if requested.

- add tests for StandardScaler covering with_mean and with_std
- adds gradient_compliant flag to StandardScaler