### PR TITLE
`split_data` function

### DIFF
--- a/docs/src/reference/utils/index.rst
+++ b/docs/src/reference/utils/index.rst
@@ -6,3 +6,4 @@ Helper classes and functions to build models.
 .. toctree::
     convert
     metrics
+    split_data

--- a/docs/src/reference/utils/split_data.rst
+++ b/docs/src/reference/utils/split_data.rst
@@ -1,0 +1,6 @@
+Splitting Equistore TensorMaps
+==============================
+
+.. automodule:: equisolve.utils.split_data
+    :members:
+    :show-inheritance:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ packages = find:
 include_package_data = True
 
 install_requires =
-    equistore @ https://github.com/lab-cosmo/equistore/archive/ee3077.zip
+    equistore @ https://github.com/lab-cosmo/equistore/archive/ee3077b.zip
     numpy
 
 [options.packages.find]

--- a/src/equisolve/__init__.py
+++ b/src/equisolve/__init__.py
@@ -8,6 +8,3 @@
 
 __version__ = "0.0.0-dev"
 __authors__ = "the equisolve development team"
-
-from .numpy import *  # noqa
-from .utils import *  # noqa

--- a/src/equisolve/__init__.py
+++ b/src/equisolve/__init__.py
@@ -8,3 +8,6 @@
 
 __version__ = "0.0.0-dev"
 __authors__ = "the equisolve development team"
+
+from .numpy import *  # noqa
+from .utils import *  # noqa

--- a/src/equisolve/utils/__init__.py
+++ b/src/equisolve/utils/__init__.py
@@ -8,6 +8,7 @@
 
 from .convert import ase_to_tensormap, properties_to_tensormap
 from .metrics import rmse
+from .split_data import split_data
 
 
 __all__ = [

--- a/src/equisolve/utils/__init__.py
+++ b/src/equisolve/utils/__init__.py
@@ -14,4 +14,5 @@ __all__ = [
     "ase_to_tensormap",
     "properties_to_tensormap",
     "rmse",
+    "split_data",
 ]

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -6,16 +6,10 @@
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
 """
-Module for splitting lists of TensorMaps into multiple smaller TensorMaps
-according to some group sizes. No explicit specification of Labels objects and
-indices is required. The main use case of this module is to aid random shuffling
-of some unique indices along a given axis followed by a subsequent
-train-test(-validation) split, but in principle could be used to split any
-number of tensors into any number of smaller tensors (up to a limit
-corresponding to the actual size of the tensor along the unique index
-dimension.)
+Module for splitting lists of :py:class:`TensorMap` objects into multiple
+:py:class:`TensorMap` objects along a given axis.
 """
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Tuple
 import numpy as np
 
 import equistore
@@ -30,34 +24,118 @@ def split_data(
     group_sizes_abs: Optional[List[int]] = None,
     group_sizes_rel: Optional[List[float]] = None,
     random_seed: Optional[int] = None,
-) -> List[List[TensorMap]]:
+) -> Tuple[List[List[TensorMap]], List[Labels]]:
     """
-    Take an input :py:class:`TensorMap` or list of :py:class:`TensorMap` objects
-    and splits each of them into multiple :py:class:`TensorMap` objects based on
-    some splitting criteria. Returns a list of :py:class:`TensorMap`
-    corresponding to the split tensors and a list of :py:class:`Labels`
-    corresponding to the unique indices along the specified ``axis`` according
-    to the specified ``names`` that are present in each of the returned groups
-    of :py:class:`TensorMap`.
-    If passing a list of :py:class:`TensorMap` objects, every
-    :py:class:`TensorMap` must have the same set of unique indices for the
-    specified ``axis`` and ``names``. They will all then be split in the same
-    way.
-    For instance, this function can be used to split 2 tensors corresponding to
-    input and output data into train and test data, with a relative 80:20 ratio:
+    Splits a list of :py:class:`TensorMap` objects into multiple
+    :py:class:`TensorMap` objects along a given axis.
+
+    For either the "samples" or "properties" `axis`, the unique indices for the
+    specified metadata `name` are found. If `random_seed` is set, the indices
+    are shuffled. Then, they are divided into `n_groups`, where the sizes of the
+    groups are specified by either the `group_sizes_abs` or `group_sizes_rel`
+    arguments.
+
+    The grouped indices are then used to split the list of input tensors. The
+    split tensors, along with the grouped indices, are returned. The tensors are
+    returned as a list of list of :py:class:`TensorMap` objects.
+
+    Each list in the returned list of list corresponds to the split
+    :py:class`TensorMap` at the same position in the input `tensors` list. Each
+    nested list contains :py:class:`TensorMap` objects that share no common
+    indices for the specified `axis` and `names`. However, the metadata on all
+    other axes (including the keys) will be equivalent.
+
+    The passed list of :py:class:`TensorMap` objects in `tensors` must have the
+    same set of unique indices for the specified `axis` and `names`. For
+    instance, if passing an input and output tensor for splitting (i.e. as used
+    in supervised machine learning), the output tensor must have structure
+    indices 0 -> 10 if the input tensor does.
+
+    :param tensors: input `list` of :py:class:`TensorMap` objects, each of
+        which will be split into `n_groups` new :py:class:`TensorMap` objects.
+    :param axis: a :py:class:`str` equal to either "samples or "properties". This is the
+        axis along which the input :py:class:`TensorMap` objects will be split.
+    :param names: a `list` of :py:class:`str` indicating the samples/properties
+        names by which the `tensors` will be split.
+    :param n_groups: an :py:class:`int` indicating how many new
+        :py:class:`TensorMap` objects each of the tensors passed in `tensors`
+        will be split into. If both `group_sizes_abs` and `group_sizes_rel`
+        are not specified, `n_groups` is used to split the data into ``n`` evenly
+        sized groups, to the nearest integer.
+    :param group_sizes_abs: an ordered `list` of `float` the absolute group
+        sizes to split each input TensorMap into. The sum of this list must be
+        <= the total number of unique indices present in the TensorMaps for the
+        chosen `axis` and `names`.
+    :param group_sizes_rel: an ordered `list` of `float` of the relative
+        group sizes to split each input TensorMap into. The sum of these float
+        values must <= 1.
+    :param random_seed: an int that seeds the numpy random number generator.
+        Used to control shuffling of the unique indices, which dictate the data
+        that ends up in each of the split output tensors. If None, no shuffling
+        of the indices occurs. If -1, shuffling occurs but with no random seed
+        set. If an integer != -1, shuffling is executed but with a random seed
+        set to this value.
+
+    :return: list of list of :py:class:`TensorMap`. The ith element in the list
+        contains `n_groups` :py:class:`TensorMap` objects corresponding to the
+        split ith :py:class:`TensorMap` of the input list `tensors`.
+    :return: list of :py:class:`Labels` corresponding to the unique indices
+        according to the specified `axis` and `names` that are present in
+        each of the returned groups of :py:class:`TensorMap`. The length of this
+        list is `n_groups`.
+
+    Examples
+    --------
+
+    Split a TensorMap `tensor` into 2 new TensorMaps along the "samples" axis
+    for the "structure" metadata. Without specifying `group_sizes_abs` or
+    `group_sizes_rel`, the data will be split equally by structure index.
+    Without specifying `random_seed`, no shuffling of the structure indices will
+    occur and they will be grouped in lexigraphical order. For instance, if the
+    input tensor has structure indices 0 -> 9 (inclusive), the first new tensor
+    will contain only structure indices 0 -> 4 (inc.) and the second will
+    contain only 5 -> 9 (inc).
+
     .. code-block:: python
+
+        from equisolve.utils import split_data
+
+        [[new_tensor_1, new_tensor_2]], grouped_idxs = split_data(
+            tensors=tensor,
+            axis="samples",
+            names=["structure"],
+            n_groups=2,
+        )
+
+    Split 2 tensors corresponding to input and output data into train and test
+    data, with a relative 80:20 ratio. If both input and output tensors contain
+    structure indices 0 -> 9 (inclusive), the `in_train` and `out_train` tensors
+    will contain structure indices 0 -> 7 (inc.) and the `in_test` and
+    `out_test` tensors will contain structure indices 8 -> 9 (inc.).
+
+    .. code-block:: python
+
+        from equisolve.utils import split_data
+
         [[in_train, in_test], [out_train, out_test]], grouped_idxs = split_data(
             tensors=[input, output],
-            axis="samples", 
+            axis="samples",
             names=["structure"],
-            n_groups=2,  # for train-test split
+            n_groups=2,                  # for train-test split
             group_sizes_rel=[0.8, 0.2],  # 80:20 train:test split
             random_seed=100,
         )
-    And for producing a train-test-validation split, where we know there are 120
-    structures in the data set, we can specify the absolute number of structures
-    in the train, test, validation sets.
+
+    Split 2 tensors corresponding to input and output data into train, test, and
+    validation data. If input and output tensors have the same 100 structure
+    indices, we can split such that the train, test, and val tensors have 70,
+    20, and 10 structures in each, respectively. Specifying the `random_seed`
+    will shuffle the structure indices before they are grouped.
+
     .. code-block:: python
+
+        from equisolve.utils import split_data
+
         (
             [
                 [in_train, in_test, in_val],
@@ -67,48 +145,10 @@ def split_data(
             tensors=[input, output],
             axis="samples",
             names=["structure"],
-            n_groups=3,  # for train-test-validation
-            group_sizes_abs=[80, 20, 10],  # 80, 25, 10 train, test, val
+            n_groups=3,                    # for train-test-validation
+            group_sizes_abs=[70, 20, 10],  # 70, 25, 10 train, test, val
             random_seed=100,
         )
-    The function finds the unique indices in the tensor(s) that correspond to
-    the chosen axis and names. These, if specified, are randomly shuffled and
-    split into groups that dictate the indices that will appear in each of the
-    output tensors.
-    This function works by calling the :py:func:`slice` function and upon
-    slicing along the samples/properties axis may produce empty
-    :py:class:`TensorBlocks` in the resulting :py:class:`TensorMap` objects.
-    :param tensors: input ``list`` of :py:class:`TensorMap` objects, each of
-        which will be split into ``n_groups`` new :py:class:`TensorMap` objects.
-    :param axis: a str equal to either "samples or "properties". This is the
-        axis along which the input :py:class:`TensorMap` objects will be split.
-    :param names: a ``list`` of ``str`` indicating the samples/properties names
-        by which the tensors will be split.
-    :param n_groups: an ``int`` indicating how many new :py:class:`TensorMap`
-        objects each of the tensors passed in ``tensors`` will be split into. If
-        both ``group_sizes_abs`` and ``group_sizes_rel`` are not specified,
-        ``ngroups`` is used to split the data into n evenly sized groups, to the
-        nearest integer.
-    :param group_sizes_abs: an ordered ``list`` of ``float`` the absolute group
-        sizes to split each input TensorMap into. The sum of this list must be
-        <= the total number of unique indices present in the TensorMaps
-        for the chosen ``axis`` and ``names``.
-    :param group_sizes_rel: an ordered ``list`` of ``float`` of the relative group
-        sizes to split each input TensorMap into. The sum of these float values
-        must <= 1.
-    :param random_seed: an int that seeds the numpy random number generator.
-        Used to control shuffling of the unique indices, which dictate the data
-        that ends up in each of the split output tensors. If None, no shuffling
-        of the indices occurs. If -1, shuffling occurs but with no random seed
-        set. If an integer != -1, shuffling is executed but with a random seed
-        set to this value.
-    :return: list of list of :py:class:`TensorMap`. The ith element in the list
-        contains ``n_groups`` :py:class:`TensorMap` objects corresponding to the
-        split ith :py:class:`TensorMap` of the input list ``tensors``.
-    :return: list of :py:class:`Labels` corresponding to the unique indices
-        according to the specified ``axis`` and ``names`` that are present in
-        each of the returned groups of :py:class:`TensorMap`. The length of this
-        list is ``n_groups``.
     """
     # Check input args
     tensors = [tensors] if isinstance(tensors, TensorMap) else tensors
@@ -117,8 +157,10 @@ def split_data(
         tensors, axis, names, n_groups, group_sizes_abs, group_sizes_rel, random_seed
     )
 
-    # Get array of unique indices to split by for each tensor in ``tensors``
-    unique_idxs_list = [equistore.unique_metadata(tensor, axis, names) for tensor in tensors]
+    # Get array of unique indices to split by for each tensor in `tensors`
+    unique_idxs_list = [
+        equistore.unique_metadata(tensor, axis, names) for tensor in tensors
+    ]
 
     # Check that the unique indices are equivalent for all input tensors
     _check_labels_equivalent(unique_idxs_list)
@@ -154,8 +196,8 @@ def split_data(
 
 def _shuffle_indices(indices: Labels, random_seed: Optional[int] = None):
     """
-    Shuffles the input Labels object ``indices`` according to the random seed.
-    If ``random_seed=None``, not shuffling is performed and the indices are just
+    Shuffles the input Labels object `indices` according to the random seed.
+    If `random_seed=None`, not shuffling is performed and the indices are just
     returned. If -1, shuffling occurs but with no random seed set. If an integer
     != -1, shuffling is executed but with a random seed set to this value.
     """
@@ -233,9 +275,9 @@ def _cascade_round(array: np.ndarray) -> np.ndarray:
 
 def _group_indices(indices: Labels, group_sizes: List[int]) -> Labels:
     """
-    Sets a numpy ``random_seed`` then randomly shuffles ``indices``. Next, these
+    Sets a numpy `random_seed` then randomly shuffles `indices`. Next, these
     indices are split into smaller groups according to the sizes specified in
-    ``group_sizes``, and returned as a list of :py:class:`Labels` objects.
+    `group_sizes`, and returned as a list of :py:class:`Labels` objects.
     """
     # Group the indices
     grouped_idxs = []
@@ -251,7 +293,7 @@ def _check_labels_equivalent(
     labels_list: List[Labels],
 ):
     """
-    Checks that all Labels objects in the input List ``labels_list`` are
+    Checks that all Labels objects in the input List `labels_list` are
     equivalent in names and values.
     """
     if len(labels_list) <= 1:
@@ -265,7 +307,7 @@ def _check_labels_equivalent(
     for label_i, test_label in enumerate(labels_list, start=1):
         if not np.array_equal(ref_labels, test_label):
             raise ValueError(
-                f"Labels objects in ``labels_list`` are not equivalent: {ref_labels} != {test_label}"
+                f"Labels objects in `labels_list` are not equivalent: {ref_labels} != {test_label}"
             )
 
 
@@ -284,7 +326,7 @@ def _searchable_labels(labels: Labels):
 
 def _labels_equal(a: Labels, b: Labels, exact_order: bool):
     """
-    For 2 :py:class:`Labels` objects ``a`` and ``b``, returns true if they are
+    For 2 :py:class:`Labels` objects `a` and `b`, returns true if they are
     exactly equivalent in names, values, and elemental positions. Assumes that
     the Labels are already searchable, i.e. they belogn to a parent TensorBlock
     or TensorMap.
@@ -308,20 +350,25 @@ def _check_args(
     random_seed: int,
 ):
     """Checks the input args for :py:func:`split_data`."""
-
     # Check tensors passed as a list
     if not isinstance(tensors, list):
-        raise TypeError("``tensors`` must be a list of equistore `TensorMap`")
+        raise TypeError(
+            f"`tensors` must be a list of equistore `TensorMap`, got {type(tensors)}"
+        )
     # Check all tensors in the list are TensorMaps
     for tensor in tensors:
         if not isinstance(tensor, TensorMap):
-            raise TypeError("``tensors`` must bes a list of equistore `TensorMap`")
+            raise TypeError(
+                f"`tensors` must bes a list of equistore `TensorMap`, got {type(tensors)}"
+            )
     # Check axis
     if axis not in ["samples", "properties"]:
-        raise ValueError("`axis` must be passsed as either 'samples' or 'properties'.")
+        raise ValueError(
+            f"`axis` must be passsed as either 'samples' or 'properties', got {axis}"
+        )
     # Check names
     if not isinstance(names, list):
-        raise TypeError("``names`` must be a list of str")
+        raise TypeError(f"`names` must be a list of str, got {type(names)}")
     for tensor in tensors:
         for _, block in tensor:
             tmp_names = (
@@ -332,40 +379,40 @@ def _check_args(
                     raise ValueError(
                         "each block of each `TensorMap` passed must have a samples "
                         + "or properties name that matches the one passed in "
-                        + "`names`."
+                        + "`names`"
                     )
     # Check n_groups
     if not isinstance(n_groups, int):
-        raise TypeError("``n_groups`` must be passed as an int.")
+        raise TypeError(f"`n_groups` must be passed as an int, got {type(n_groups)}")
 
     # Check group_sizes_abs and group_sizes_rel
     if group_sizes_abs is not None:
         # Length is the same as n_groups
         if len(group_sizes_abs) != n_groups:
             raise ValueError(
-                "if specifying ``group_sizes_abs`` to split the tensors by, the list must"
-                + " have the same number of elements as indicated by `n_groups`."
+                "if specifying `group_sizes_abs` to split the tensors by, the list must"
+                + " have the same number of elements as indicated by `n_groups`"
             )
         # group_sizes_rel isn't specified too
         if group_sizes_rel is not None:
             raise ValueError(
-                "can only specify `group_sizes_abs` or `group_sizes_rel`, but not both."
+                "can only specify `group_sizes_abs` or `group_sizes_rel`, but not both"
             )
     else:
         if group_sizes_rel is not None:
             # Length is the same as n_groups
             if len(group_sizes_rel) != n_groups:
                 raise ValueError(
-                    "if specifying ``group_sizes_rel`` to split the tensors by, the list "
-                    + "must have the same number of elements as indicated by ``n_groups`."
+                    "if specifying `group_sizes_rel` to split the tensors by, the list "
+                    + "must have the same number of elements as indicated by `n_groups`"
                 )
             # Sum of the parts is 1
             if np.sum(group_sizes_rel) > 1:
                 raise ValueError(
-                    "if specifying ``group_sizes_rel``, the sum of the values in the list"
+                    "if specifying `group_sizes_rel`, the sum of the values in the list"
                     + " must be <= 1"
                 )
     # Check random_seed
     if random_seed is not None:
         if not isinstance(random_seed, int):
-            raise TypeError("``random_seed`` must be passed as an `int`.")
+            raise TypeError("`random_seed` must be passed as an `int`")

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -229,17 +229,8 @@ def split_data(
 
     # Split each of the input TensorMaps
     split_tensors = []
-    for i, tensor in enumerate(tensors):
+    for tensor in tensors:
         split_tensors.append(equistore.split(tensor, axis, grouped_labels))
-
-    # Check the indices of the split tensors. the jth TensorMap in every list of
-    # split tensors should have equivalent unique indices.
-    for j in range(len(split_tensors[0])):
-        unq_idxs_list = [
-            equistore.unique_metadata(split_tensors[i][j], axis, names)
-            for i in range(len(split_tensors))
-        ]
-        _check_labels_equivalent(unq_idxs_list)
 
     return split_tensors, grouped_labels
 

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -1,0 +1,371 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2023 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the BSD 3-Clause "New" or "Revised" License
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Module for splitting lists of TensorMaps into multiple smaller TensorMaps
+according to some group sizes. No explicit specification of Labels objects and
+indices is required. The main use case of this module is to aid random shuffling
+of some unique indices along a given axis followed by a subsequent
+train-test(-validation) split, but in principle could be used to split any
+number of tensors into any number of smaller tensors (up to a limit
+corresponding to the actual size of the tensor along the unique index
+dimension.)
+"""
+from typing import List, Union, Optional
+import numpy as np
+
+import equistore
+from equistore import Labels, TensorBlock, TensorMap
+
+
+def split_data(
+    tensors: Union[List[TensorMap], TensorMap],
+    axis: str,
+    names: Union[List[str], str],
+    n_groups: int,
+    group_sizes_abs: Optional[List[int]] = None,
+    group_sizes_rel: Optional[List[float]] = None,
+    random_seed: Optional[int] = None,
+) -> List[List[TensorMap]]:
+    """
+    Take an input :py:class:`TensorMap` or list of :py:class:`TensorMap` objects
+    and splits each of them into multiple :py:class:`TensorMap` objects based on
+    some splitting criteria. Returns a list of :py:class:`TensorMap`
+    corresponding to the split tensors and a list of :py:class:`Labels`
+    corresponding to the unique indices along the specified ``axis`` according
+    to the specified ``names`` that are present in each of the returned groups
+    of :py:class:`TensorMap`.
+    If passing a list of :py:class:`TensorMap` objects, every
+    :py:class:`TensorMap` must have the same set of unique indices for the
+    specified ``axis`` and ``names``. They will all then be split in the same
+    way.
+    For instance, this function can be used to split 2 tensors corresponding to
+    input and output data into train and test data, with a relative 80:20 ratio:
+    .. code-block:: python
+        [[in_train, in_test], [out_train, out_test]], grouped_idxs = split_data(
+            tensors=[input, output],
+            axis="samples", 
+            names=["structure"],
+            n_groups=2,  # for train-test split
+            group_sizes_rel=[0.8, 0.2],  # 80:20 train:test split
+            random_seed=100,
+        )
+    And for producing a train-test-validation split, where we know there are 120
+    structures in the data set, we can specify the absolute number of structures
+    in the train, test, validation sets.
+    .. code-block:: python
+        (
+            [
+                [in_train, in_test, in_val],
+                [out_train, out_test, out_val]
+            ]
+        ), grouped_idxs = split_data(
+            tensors=[input, output],
+            axis="samples",
+            names=["structure"],
+            n_groups=3,  # for train-test-validation
+            group_sizes_abs=[80, 20, 10],  # 80, 25, 10 train, test, val
+            random_seed=100,
+        )
+    The function finds the unique indices in the tensor(s) that correspond to
+    the chosen axis and names. These, if specified, are randomly shuffled and
+    split into groups that dictate the indices that will appear in each of the
+    output tensors.
+    This function works by calling the :py:func:`slice` function and upon
+    slicing along the samples/properties axis may produce empty
+    :py:class:`TensorBlocks` in the resulting :py:class:`TensorMap` objects.
+    :param tensors: input ``list`` of :py:class:`TensorMap` objects, each of
+        which will be split into ``n_groups`` new :py:class:`TensorMap` objects.
+    :param axis: a str equal to either "samples or "properties". This is the
+        axis along which the input :py:class:`TensorMap` objects will be split.
+    :param names: a ``list`` of ``str`` indicating the samples/properties names
+        by which the tensors will be split.
+    :param n_groups: an ``int`` indicating how many new :py:class:`TensorMap`
+        objects each of the tensors passed in ``tensors`` will be split into. If
+        both ``group_sizes_abs`` and ``group_sizes_rel`` are not specified,
+        ``ngroups`` is used to split the data into n evenly sized groups, to the
+        nearest integer.
+    :param group_sizes_abs: an ordered ``list`` of ``float`` the absolute group
+        sizes to split each input TensorMap into. The sum of this list must be
+        <= the total number of unique indices present in the TensorMaps
+        for the chosen ``axis`` and ``names``.
+    :param group_sizes_rel: an ordered ``list`` of ``float`` of the relative group
+        sizes to split each input TensorMap into. The sum of these float values
+        must <= 1.
+    :param random_seed: an int that seeds the numpy random number generator.
+        Used to control shuffling of the unique indices, which dictate the data
+        that ends up in each of the split output tensors. If None, no shuffling
+        of the indices occurs. If -1, shuffling occurs but with no random seed
+        set. If an integer != -1, shuffling is executed but with a random seed
+        set to this value.
+    :return: list of list of :py:class:`TensorMap`. The ith element in the list
+        contains ``n_groups`` :py:class:`TensorMap` objects corresponding to the
+        split ith :py:class:`TensorMap` of the input list ``tensors``.
+    :return: list of :py:class:`Labels` corresponding to the unique indices
+        according to the specified ``axis`` and ``names`` that are present in
+        each of the returned groups of :py:class:`TensorMap`. The length of this
+        list is ``n_groups``.
+    """
+    # Check input args
+    tensors = [tensors] if isinstance(tensors, TensorMap) else tensors
+    names = [names] if isinstance(names, str) else names
+    _check_args(
+        tensors, axis, names, n_groups, group_sizes_abs, group_sizes_rel, random_seed
+    )
+
+    # Get array of unique indices to split by for each tensor in ``tensors``
+    unique_idxs_list = [equistore.unique_metadata(tensor, axis, names) for tensor in tensors]
+
+    # Check that the unique indices are equivalent for all input tensors
+    _check_labels_equivalent(unique_idxs_list)
+    unique_idxs = unique_idxs_list[0]
+
+    # Shuffle the unique indices according to the random seed
+    _shuffle_indices(unique_idxs, random_seed)
+
+    # Get group sizes
+    group_sizes = _get_group_sizes(
+        n_groups, len(unique_idxs), group_sizes_abs, group_sizes_rel
+    )
+
+    # Group the indices according to the group sizes
+    grouped_idxs = _group_indices(unique_idxs, group_sizes)
+
+    # Split each of the input TensorMaps
+    split_tensors = []
+    for i, tensor in enumerate(tensors):
+        split_tensors.append(equistore.split(tensor, axis, grouped_idxs))
+
+    # Check the indices of the split tensors. the jth TensorMap in every list of
+    # split tensors should have equivalent unique indices.
+    for j in range(len(split_tensors[0])):
+        unq_idxs_list = [
+            equistore.unique_metadata(split_tensors[i][j], axis, names)
+            for i in range(len(split_tensors))
+        ]
+        _check_labels_equivalent(unq_idxs_list)
+
+    return split_tensors, grouped_idxs
+
+
+def _shuffle_indices(indices: Labels, random_seed: Optional[int] = None):
+    """
+    Shuffles the input Labels object ``indices`` according to the random seed.
+    If ``random_seed=None``, not shuffling is performed and the indices are just
+    returned. If -1, shuffling occurs but with no random seed set. If an integer
+    != -1, shuffling is executed but with a random seed set to this value.
+    """
+    if random_seed is not None:  # shuffle
+        if random_seed != -1:  # set a numpy random seed
+            np.random.seed(random_seed)
+        np.random.shuffle(indices)
+    return
+
+
+def _get_group_sizes(
+    n_groups: int,
+    n_indices: int,
+    group_sizes_abs: Optional[List[float]] = None,
+    group_sizes_rel: Optional[List[int]] = None,
+) -> np.ndarray:
+    """
+    Parses the group sizes args from :py:func:`split_data` and returns an array
+    of group sizes in absolute numbers.
+    :param n_groups: an int, the number of groups to split the data into
+    :param n_indices: an int, the number of unique indices present in the data
+        by which the data should be grouped.
+    :param group_sizes_abs:
+    """
+    # Must be at least as many unique indices as groups
+    if not (n_indices >= n_groups):
+        raise ValueError(
+            "you must specify at least as many groups as there are indices to split."
+        )
+    if group_sizes_abs is None:
+        if group_sizes_rel is None:
+            # Equally sized groups
+            group_sizes = np.array([1 / n_groups] * n_groups) * n_indices
+        else:
+            # Convert relative group sizes to absolute group sizes
+            group_sizes = np.array(group_sizes_rel) * n_indices
+    else:
+        # Already in absolute; just convert to an array
+        group_sizes = np.array(group_sizes_abs)
+
+    # The group sizes may not be integers. Use cascade rounding to round them
+    # all to integers whilst attempting to minimize rounding error.
+    group_sizes = _cascade_round(group_sizes)
+
+    return group_sizes
+
+
+def _cascade_round(array: np.ndarray) -> np.ndarray:
+    """
+    Given an array of floats that sum to an integer, this rounds the floats
+    and returns an array of integers with the same sum.
+    Adapted from https://jsfiddle.net/cd8xqy6e/.
+    """
+    # Check type
+    if not isinstance(array, np.ndarray):
+        raise TypeError("must pass `array` as a numpy array.")
+    # Check sum
+    mod = np.sum(array) % 1
+    if not np.isclose(round(mod) - mod, 0):
+        raise ValueError("elements of `array` must sum to an integer.")
+
+    float_tot, integer_tot = 0, 0
+    rounded_array = []
+    for element in array:
+        new_int = round(element + float_tot) - integer_tot
+        float_tot += element
+        integer_tot += new_int
+        rounded_array.append(new_int)
+
+    # Check that the sum is preserved
+    assert round(np.sum(array)) == round(np.sum(rounded_array))
+
+    return np.array(rounded_array)
+
+
+def _group_indices(indices: Labels, group_sizes: List[int]) -> Labels:
+    """
+    Sets a numpy ``random_seed`` then randomly shuffles ``indices``. Next, these
+    indices are split into smaller groups according to the sizes specified in
+    ``group_sizes``, and returned as a list of :py:class:`Labels` objects.
+    """
+    # Group the indices
+    grouped_idxs = []
+    prev_size = 0
+    for i, size in enumerate(group_sizes):
+        grouped_idxs.append(indices[prev_size : prev_size + size])
+        prev_size += size
+
+    return grouped_idxs
+
+
+def _check_labels_equivalent(
+    labels_list: List[Labels],
+):
+    """
+    Checks that all Labels objects in the input List ``labels_list`` are
+    equivalent in names and values.
+    """
+    if len(labels_list) <= 1:
+        return
+    # Define reference Labels object as the first in the list
+    try:
+        ref_labels = _searchable_labels(labels_list[0])
+    except AttributeError:
+        # Labels obj is already searchable
+        ref_labels = labels_list[0]
+    for label_i, test_label in enumerate(labels_list, start=1):
+        if not np.array_equal(ref_labels, test_label):
+            raise ValueError(
+                f"Labels objects in ``labels_list`` are not equivalent: {ref_labels} != {test_label}"
+            )
+
+
+def _searchable_labels(labels: Labels):
+    """
+    Returns the input Labels object but after being used to construct a
+    TensorBlock, so that look-ups can be performed.
+    """
+    return TensorBlock(
+        values=np.full((len(labels), 1), 0.0),
+        samples=labels,
+        components=[],
+        properties=Labels(["p"], np.array([[0]], dtype=np.int32)),
+    ).samples
+
+
+def _labels_equal(a: Labels, b: Labels, exact_order: bool):
+    """
+    For 2 :py:class:`Labels` objects ``a`` and ``b``, returns true if they are
+    exactly equivalent in names, values, and elemental positions. Assumes that
+    the Labels are already searchable, i.e. they belogn to a parent TensorBlock
+    or TensorMap.
+    """
+    # They can only be equivalent if the same length
+    if len(a) != len(b):
+        return False
+    if exact_order:
+        return np.all(np.array(a == b))
+    else:
+        return np.all([a_i in b for a_i in a])
+
+
+def _check_args(
+    tensors: List[TensorMap],
+    axis: str,
+    names: List[str],
+    n_groups: int,
+    group_sizes_abs: List[int],
+    group_sizes_rel: List[float],
+    random_seed: int,
+):
+    """Checks the input args for :py:func:`split_data`."""
+
+    # Check tensors passed as a list
+    if not isinstance(tensors, list):
+        raise TypeError("``tensors`` must be a list of equistore `TensorMap`")
+    # Check all tensors in the list are TensorMaps
+    for tensor in tensors:
+        if not isinstance(tensor, TensorMap):
+            raise TypeError("``tensors`` must bes a list of equistore `TensorMap`")
+    # Check axis
+    if axis not in ["samples", "properties"]:
+        raise ValueError("`axis` must be passsed as either 'samples' or 'properties'.")
+    # Check names
+    if not isinstance(names, list):
+        raise TypeError("``names`` must be a list of str")
+    for tensor in tensors:
+        for _, block in tensor:
+            tmp_names = (
+                block.samples.names if axis == "samples" else block.properties.names
+            )
+            for name in names:
+                if name not in tmp_names:
+                    raise ValueError(
+                        "each block of each `TensorMap` passed must have a samples "
+                        + "or properties name that matches the one passed in "
+                        + "`names`."
+                    )
+    # Check n_groups
+    if not isinstance(n_groups, int):
+        raise TypeError("``n_groups`` must be passed as an int.")
+
+    # Check group_sizes_abs and group_sizes_rel
+    if group_sizes_abs is not None:
+        # Length is the same as n_groups
+        if len(group_sizes_abs) != n_groups:
+            raise ValueError(
+                "if specifying ``group_sizes_abs`` to split the tensors by, the list must"
+                + " have the same number of elements as indicated by `n_groups`."
+            )
+        # group_sizes_rel isn't specified too
+        if group_sizes_rel is not None:
+            raise ValueError(
+                "can only specify `group_sizes_abs` or `group_sizes_rel`, but not both."
+            )
+    else:
+        if group_sizes_rel is not None:
+            # Length is the same as n_groups
+            if len(group_sizes_rel) != n_groups:
+                raise ValueError(
+                    "if specifying ``group_sizes_rel`` to split the tensors by, the list "
+                    + "must have the same number of elements as indicated by ``n_groups`."
+                )
+            # Sum of the parts is 1
+            if np.sum(group_sizes_rel) > 1:
+                raise ValueError(
+                    "if specifying ``group_sizes_rel``, the sum of the values in the list"
+                    + " must be <= 1"
+                )
+    # Check random_seed
+    if random_seed is not None:
+        if not isinstance(random_seed, int):
+            raise TypeError("``random_seed`` must be passed as an `int`.")

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -54,8 +54,8 @@ def split_data(
     :param axis: a :py:class:`str` equal to either "samples" or "properties".
         This is the axis along which the input :py:class:`TensorMap` objects
         will be split.
-    :param names: a `list` of :py:class:`str` indicating the samples/properties
-        names by which the `tensors` will be split.
+    :param names: a :py:class:`list` of :py:class:`str` indicating the
+        samples/properties names by which the `tensors` will be split.
     :param n_groups: an :py:class:`int` indicating how many new
         :py:class:`TensorMap` objects each of the tensors passed in `tensors`
         will be split into. If `group_sizes` is none (default), `n_groups` is
@@ -78,7 +78,7 @@ def split_data(
         this value.
 
     :return split_tensors: :py:class:`list` of :py:class:`list` of
-        :py:class:`TensorMap`. The ``i``th element in the list contains
+        :py:class:`TensorMap`. The ``i`` th element in the list contains
         `n_groups` :py:class:`TensorMap` objects corresponding to the split ith
         :py:class:`TensorMap` of the input list `tensors`.
     :return grouped_labels: list of :py:class:`Labels` corresponding to the

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -9,10 +9,10 @@
 Module for splitting lists of :py:class:`TensorMap` objects into multiple
 :py:class:`TensorMap` objects along a given axis.
 """
-from typing import List, Union, Optional, Tuple
-import numpy as np
+from typing import List, Optional, Tuple, Union
 
 import equistore
+import numpy as np
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -427,4 +427,6 @@ def _check_args(
     # Check random_seed
     if random_seed is not None:
         if not isinstance(random_seed, int):
-            raise TypeError(f"`random_seed` must be passed as an `int`, got {type(random_seed)}")
+            raise TypeError(
+                f"`random_seed` must be passed as an `int`, got {type(random_seed)}"
+            )

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -22,26 +22,26 @@ def split_data(
     names: Union[List[str], str],
     n_groups: int,
     group_sizes: Optional[Union[List[int], List[float]]] = None,
-    random_seed: Optional[int] = None,
+    seed: Optional[int] = None,
 ) -> Tuple[List[List[TensorMap]], List[Labels]]:
     """
     Splits a list of :py:class:`TensorMap` objects into multiple
     :py:class:`TensorMap` objects along a given axis.
 
     For either the "samples" or "properties" `axis`, the unique indices for the
-    specified metadata `name` are found. If `random_seed` is set, the indices
-    are shuffled. Then, they are divided into `n_groups`, where the sizes of the
+    specified metadata `name` are found. If `seed` is set, the indices are
+    shuffled. Then, they are divided into `n_groups`, where the sizes of the
     groups are specified by the `group_sizes` argument.
 
     These grouped indices are then used to split the list of input tensors. The
     split tensors, along with the grouped labels, are returned. The tensors are
     returned as a list of list of :py:class:`TensorMap` objects.
 
-    Each list in the returned list of list corresponds to the split
-    :py:class`TensorMap` at the same position in the input `tensors` list. Each
-    nested list contains :py:class:`TensorMap` objects that share no common
-    indices for the specified `axis` and `names`. However, the metadata on all
-    other axes (including the keys) will be equivalent.
+    Each list in the returned :py:class:`list` of :py:class:`list` corresponds
+    to the split :py:class`TensorMap` at the same position in the input
+    `tensors` list. Each nested list contains :py:class:`TensorMap` objects that
+    share no common indices for the specified `axis` and `names`. However, the
+    metadata on all other axes (including the keys) will be equivalent.
 
     The passed list of :py:class:`TensorMap` objects in `tensors` must have the
     same set of unique indices for the specified `axis` and `names`. For
@@ -51,7 +51,7 @@ def split_data(
 
     :param tensors: input `list` of :py:class:`TensorMap` objects, each of which
         will be split into `n_groups` new :py:class:`TensorMap` objects.
-    :param axis: a :py:class:`str` equal to either "samples or "properties".
+    :param axis: a :py:class:`str` equal to either "samples" or "properties".
         This is the axis along which the input :py:class:`TensorMap` objects
         will be split.
     :param names: a `list` of :py:class:`str` indicating the samples/properties
@@ -62,24 +62,25 @@ def split_data(
         used to split the data into ``n`` evenly sized groups according to the
         unique metadata for the specified `axis` and `names`, to the nearest
         integer.
-    :param group_sizes: an ordered `list` of `float` the group sizes to split
-        each input TensorMap into. A list of int will be interpreted as an
-        indication of the absolute group sizes, whereas a list of float as
-        indicating the relative sizes. For the former case, the sum of this list
-        must be <= the total number of unique indices present in the input
-        `tensors` for the chosen `axis` and `names`. In the latter, the sum of
-        this list must be <= 1.
-    :param random_seed: an int that seeds the numpy random number generator.
-        Used to control shuffling of the unique indices, which dictate the data
-        that ends up in each of the split output tensors. If None, no shuffling
-        of the indices occurs. If -1, shuffling occurs but with no random seed
-        set. If an integer != -1, shuffling is executed but with a random seed
-        set to this value.
+    :param group_sizes: an ordered :py:class:`list` of :py:class:`float` the
+        group sizes to split each input :py:class:`TensorMap` into. A
+        :py:class:`list` of :py:class:`int` will be interpreted as an indication
+        of the absolute group sizes, whereas a list of float as indicating the
+        relative sizes. For the former case, the sum of this list must be <= the
+        total number of unique indices present in the input `tensors` for the
+        chosen `axis` and `names`. In the latter, the sum of this list must be
+        <= 1.
+    :param seed: an :py:class:`int` that seeds the numpy random number
+        generator. Used to control shuffling of the unique indices, which
+        dictate the data that ends up in each of the split output tensors. If
+        None (default), no shuffling of the indices occurs. If a
+        :py:class:`int`, shuffling is executed but with a random seed set to
+        this value.
 
-    :return split_tensors: list of list of :py:class:`TensorMap`. The ith
-        element in the list contains `n_groups` :py:class:`TensorMap` objects
-        corresponding to the split ith :py:class:`TensorMap` of the input list
-        `tensors`.
+    :return split_tensors: :py:class:`list` of :py:class:`list` of
+        :py:class:`TensorMap`. The ``i``th element in the list contains
+        `n_groups` :py:class:`TensorMap` objects corresponding to the split ith
+        :py:class:`TensorMap` of the input list `tensors`.
     :return grouped_labels: list of :py:class:`Labels` corresponding to the
         unique indices according to the specified `axis` and `names` that are
         present in each of the returned groups of :py:class:`TensorMap`. The
@@ -93,7 +94,7 @@ def split_data(
     will be split equally by structure index. If the number of unique strutcure
     indices present in the input data is not exactly divisible by `n_groups`,
     the group sizes will be made to the nearest int. Without specifying
-    `random_seed`, no shuffling of the structure indices will occur and they
+    `seed`, no shuffling of the structure indices will occur and they
     will be grouped in lexigraphical order. For instance, if the input tensor
     has structure indices 0 -> 9 (inclusive), the first new tensor will contain
     only structure indices 0 -> 4 (inc.) and the second will contain only 5 -> 9
@@ -116,7 +117,7 @@ def split_data(
     will contain structure indices 0 -> 7 (inc.) and the `in_test` and
     `out_test` tensors will contain structure indices 8 -> 9 (inc.). As we want
     to specify relative group sizes, we will pass `group_sizes` as a list of
-    float. Specifying the `random_seed` will shuffle the structure indices
+    float. Specifying the `seed` will shuffle the structure indices
     before the groups are made.
 
     .. code-block:: python
@@ -129,14 +130,14 @@ def split_data(
             names=["structure"],
             n_groups=2,                  # for train-test split
             group_sizes=[0.8, 0.2],  # relative, a 80% 20% train-test split
-            random_seed=100,
+            seed=100,
         )
 
     Split 2 tensors corresponding to input and output data into train, test, and
     validation data. If input and output tensors have the same 10 structure
     indices, we can split such that the train, test, and val tensors have 7,
     2, and 1 structures in each, respectively. We want to specify absolute
-    group sizes, so will pass a list of int. Specifying the `random_seed` will
+    group sizes, so will pass a list of int. Specifying the `seed` will
     shuffle the structure indices before they are grouped.
 
     .. code-block:: python
@@ -173,7 +174,7 @@ def split_data(
             names=["structure"],
             n_groups=3,  # for train-test-validation
             group_sizes=[7, 2, 1],  # absolute; 7, 2, 1 for train, test, val
-            random_seed=100,
+            seed=100,
         )
         # Inspect the grouped structure indices
         grouped_labels
@@ -189,7 +190,7 @@ def split_data(
     # Check input args and parse `tensors` and `names` into lists
     tensors = [tensors] if isinstance(tensors, TensorMap) else tensors
     names = [names] if isinstance(names, str) else names
-    _check_args(tensors, axis, names, n_groups, group_sizes, random_seed)
+    _check_args(tensors, axis, names, n_groups, group_sizes, seed)
 
     # Get array of unique indices to split by for each tensor in `tensors`
     unique_idxs_list = [
@@ -200,16 +201,18 @@ def split_data(
     _check_labels_equivalent(unique_idxs_list)
     unique_idxs = unique_idxs_list[0]
 
-    # Shuffle the unique indices according to the random seed
-    _shuffle_indices(unique_idxs, random_seed)
+    # Shuffle the unique indices according to the random seed if specified
+    if seed is not None:
+        rng = np.random.default_rng(seed)
+        rng.shuffle(unique_idxs)
 
     # Must be at least as many unique indices as groups
     n_indices = len(unique_idxs)
     if n_indices < n_groups:
         raise ValueError(
             f"the number of groups specified ({n_groups}) is greater than the"
-            + f" number of unique metadata indices ({n_indices}) for the"
-            + f" chosen axis {axis} and names {names}: {unique_idxs}"
+            f" number of unique metadata indices ({n_indices}) for the"
+            f" chosen axis {axis} and names {names}: {unique_idxs}"
         )
 
     # Get group sizes
@@ -220,8 +223,8 @@ def split_data(
     if n_indices < sum(group_sizes):
         raise ValueError(
             f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater than "
-            + f"the number of unique metadata indices ({n_indices}) for the chosen "
-            + f"axis {axis} and names {names}: {unique_idxs}"
+            f"the number of unique metadata indices ({n_indices}) for the chosen "
+            f"axis {axis} and names {names}: {unique_idxs}"
         )
 
     # Group the indices according to the group sizes
@@ -235,20 +238,6 @@ def split_data(
     return split_tensors, grouped_labels
 
 
-def _shuffle_indices(indices: Labels, random_seed: Optional[int] = None):
-    """
-    Shuffles the input Labels object `indices` according to the random seed. If
-    `random_seed=None`, not shuffling is performed and the indices are just
-    returned. If -1, shuffling occurs but with no random seed set. If an integer
-    != -1, shuffling is executed but with a random seed set to this value. There
-    is no return value, as the input `indices` is shuffled in place.
-    """
-    if random_seed is not None:  # shuffle
-        if random_seed != -1:  # set a numpy random seed
-            np.random.seed(random_seed)
-        np.random.shuffle(indices)
-
-
 def _get_group_sizes(
     n_groups: int,
     n_indices: int,
@@ -256,7 +245,17 @@ def _get_group_sizes(
 ) -> np.ndarray:
     """
     Parses the `group_sizes` arg from :py:func:`split_data` and returns an array
-    of group sizes in absolute numbers.
+    of group sizes in absolute terms. If `group_sizes` is None, the group sizes
+    returned are (to the nearest integer) evenly distributed across the number
+    of unique indices; i.e. if there are 12 unique indices (`n_indices=10`), and
+    `n_groups` is 3, the group sizes returned will be np.array([4, 4, 4]). If
+    `group_sizes` is specified as a list of floats (i.e. relative sizes, whose
+    sum is <= 1), the group sizes returned are converted to absolute sizes, i.e.
+    multiplied by `n_indices`. If `group_sizes` is specified as a list of int,
+    no conversion is performed. A cascade round is used to make sure that the
+    group sizes are integers, with the sum of the list preserved and the
+    rounding error minimized.
+
 
     :param n_groups: an int, the number of groups to split the data into :param
         n_indices: an int, the number of unique indices present in the data by
@@ -314,8 +313,7 @@ def _cascade_round(array: np.ndarray) -> np.ndarray:
 
 def _group_indices(indices: Labels, group_sizes: List[int]) -> Labels:
     """
-    Sets a numpy `random_seed` then randomly shuffles `indices`. Next, these
-    indices are split into smaller groups according to the sizes specified in
+    Splits `indices` into smaller groups according to the sizes specified in
     `group_sizes`, and returned as a list of :py:class:`Labels` objects.
     """
     # Group the indices
@@ -344,7 +342,7 @@ def _check_labels_equivalent(
         if not np.array_equal(ref_labels, test_label):
             raise ValueError(
                 "Labels objects in `labels_list` are not equivalent:"
-                + f" {ref_labels} != {test_label}"
+                f" {ref_labels} != {test_label}"
             )
 
 
@@ -354,7 +352,7 @@ def _check_args(
     names: List[str],
     n_groups: int,
     group_sizes: Optional[Union[List[float], List[int]]],
-    random_seed: Optional[int],
+    seed: Optional[int],
 ):
     """Checks the input args for :py:func:`split_data`."""
     # Check tensors passed as a list
@@ -367,7 +365,7 @@ def _check_args(
         if not isinstance(tensor, TensorMap):
             raise TypeError(
                 "`tensors` must be a list of equistore `TensorMap`,"
-                + f" got {type(tensors)}"
+                f" got {type(tensors)}"
             )
     # Check axis
     if not isinstance(axis, str):
@@ -387,7 +385,7 @@ def _check_args(
             if name not in tmp_names:
                 raise ValueError(
                     f"the passed `TensorMap` objects have {axis} names {tmp_names}"
-                    + f" that do not match the one passed in `names` {names}"
+                    f" that do not match the one passed in `names` {names}"
                 )
     # Check n_groups
     if not isinstance(n_groups, int):
@@ -399,33 +397,31 @@ def _check_args(
         if not isinstance(group_sizes, list):
             raise TypeError(
                 "`group_sizes` must be passed as a list of float or int,"
-                + f" got {type(group_sizes)}"
+                f" got {type(group_sizes)}"
             )
         if len(group_sizes) != n_groups:
             raise ValueError(
                 "if specifying `group_sizes`, you must pass a list whose"
-                + " number of elements equal to `n_groups`"
+                " number of elements equal to `n_groups`"
             )
         for size in group_sizes:
             if not isinstance(size, (int, float)):
                 raise TypeError(
                     "`group_sizes` must be passed as a list of float or int,"
-                    + f" got {type(group_sizes)}"
+                    f" got {type(group_sizes)}"
                 )
             if not size > 0:
                 raise ValueError(
                     "all elements of `group_sizes` must be greater than 0,"
-                    + f" got {group_sizes}"
+                    f" got {group_sizes}"
                 )
         if np.all([isinstance(size, float) for size in group_sizes]):
             if np.sum(group_sizes) > 1:
                 raise ValueError(
                     "if specifying `group_sizes` as a list of float, the sum of"
-                    + " the list must be less than or equal to 1"
+                    " the list must be less than or equal to 1"
                 )
-    # Check random_seed
-    if random_seed is not None:
-        if not isinstance(random_seed, int):
-            raise TypeError(
-                f"`random_seed` must be passed as an `int`, got {type(random_seed)}"
-            )
+    # Check seed
+    if seed is not None:
+        if not isinstance(seed, int):
+            raise TypeError(f"`seed` must be passed as an `int`, got {type(seed)}")

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple, Union
 
 import equistore
 import numpy as np
-from equistore import Labels, TensorBlock, TensorMap
+from equistore import Labels, TensorMap
 
 
 def split_data(
@@ -178,7 +178,10 @@ def split_data(
         # Inspect the grouped structure indices
         grouped_labels
         >>> [
-            Labels([(3,), (7,), (1,), (8,), (0,), (9,), (2,)], dtype=[('structure', '<i4')]),
+            Labels(
+                [(3,), (7,), (1,), (8,), (0,), (9,), (2,)],
+                dtype=[('structure', '<i4')]
+            ),
             Labels([(4,), (6,)], dtype=[('structure', '<i4')]),
             Labels([(5,)], dtype=[('structure', '<i4')]),
         ]
@@ -204,9 +207,9 @@ def split_data(
     n_indices = len(unique_idxs)
     if n_indices < n_groups:
         raise ValueError(
-            f"the number of groups specified ({n_groups}) is greater than the number of "
-            + f" unique metadata indices ({n_indices}) for the chosen axis {axis} and"
-            + f" names {names}: {unique_idxs}"
+            f"the number of groups specified ({n_groups}) is greater than the"
+            + f" number of unique metadata indices ({n_indices}) for the"
+            + f" chosen axis {axis} and names {names}: {unique_idxs}"
         )
 
     # Get group sizes
@@ -327,7 +330,7 @@ def _group_indices(indices: Labels, group_sizes: List[int]) -> Labels:
     # Group the indices
     grouped_labels = []
     prev_size = 0
-    for i, size in enumerate(group_sizes):
+    for size in group_sizes:
         grouped_labels.append(indices[prev_size : prev_size + size])
         prev_size += size
 
@@ -349,7 +352,8 @@ def _check_labels_equivalent(
         test_label = labels_list[label_i]
         if not np.array_equal(ref_labels, test_label):
             raise ValueError(
-                f"Labels objects in `labels_list` are not equivalent: {ref_labels} != {test_label}"
+                "Labels objects in `labels_list` are not equivalent:"
+                + f" {ref_labels} != {test_label}"
             )
 
 
@@ -371,7 +375,8 @@ def _check_args(
     for tensor in tensors:
         if not isinstance(tensor, TensorMap):
             raise TypeError(
-                f"`tensors` must be a list of equistore `TensorMap`, got {type(tensors)}"
+                "`tensors` must be a list of equistore `TensorMap`,"
+                + f" got {type(tensors)}"
             )
     # Check axis
     if not isinstance(axis, str):
@@ -402,7 +407,8 @@ def _check_args(
     if group_sizes is not None:
         if not isinstance(group_sizes, list):
             raise TypeError(
-                f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
+                "`group_sizes` must be passed as a list of float or int,"
+                + f" got {type(group_sizes)}"
             )
         if len(group_sizes) != n_groups:
             raise ValueError(
@@ -412,11 +418,13 @@ def _check_args(
         for size in group_sizes:
             if not isinstance(size, (int, float)):
                 raise TypeError(
-                    f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
+                    "`group_sizes` must be passed as a list of float or int,"
+                    + f" got {type(group_sizes)}"
                 )
             if not size > 0:
                 raise ValueError(
-                    f"all elements of `group_sizes` must be greater than 0, got {group_sizes}"
+                    "all elements of `group_sizes` must be greater than 0,"
+                    + f" got {group_sizes}"
                 )
         if np.all([isinstance(size, float) for size in group_sizes]):
             if np.sum(group_sizes) > 1:

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -21,8 +21,7 @@ def split_data(
     axis: str,
     names: Union[List[str], str],
     n_groups: int,
-    group_sizes_abs: Optional[List[int]] = None,
-    group_sizes_rel: Optional[List[float]] = None,
+    group_sizes: Optional[Union[List[int], List[float]]] = None,
     random_seed: Optional[int] = None,
 ) -> Tuple[List[List[TensorMap]], List[Labels]]:
     """
@@ -32,11 +31,10 @@ def split_data(
     For either the "samples" or "properties" `axis`, the unique indices for the
     specified metadata `name` are found. If `random_seed` is set, the indices
     are shuffled. Then, they are divided into `n_groups`, where the sizes of the
-    groups are specified by either the `group_sizes_abs` or `group_sizes_rel`
-    arguments.
+    groups are specified by the `group_sizes` argument.
 
-    The grouped indices are then used to split the list of input tensors. The
-    split tensors, along with the grouped indices, are returned. The tensors are
+    These grouped indices are then used to split the list of input tensors. The
+    split tensors, along with the grouped labels, are returned. The tensors are
     returned as a list of list of :py:class:`TensorMap` objects.
 
     Each list in the returned list of list corresponds to the split
@@ -51,24 +49,26 @@ def split_data(
     in supervised machine learning), the output tensor must have structure
     indices 0 -> 10 if the input tensor does.
 
-    :param tensors: input `list` of :py:class:`TensorMap` objects, each of
-        which will be split into `n_groups` new :py:class:`TensorMap` objects.
-    :param axis: a :py:class:`str` equal to either "samples or "properties". This is the
-        axis along which the input :py:class:`TensorMap` objects will be split.
+    :param tensors: input `list` of :py:class:`TensorMap` objects, each of which
+        will be split into `n_groups` new :py:class:`TensorMap` objects.
+    :param axis: a :py:class:`str` equal to either "samples or "properties".
+        This is the axis along which the input :py:class:`TensorMap` objects
+        will be split.
     :param names: a `list` of :py:class:`str` indicating the samples/properties
         names by which the `tensors` will be split.
     :param n_groups: an :py:class:`int` indicating how many new
         :py:class:`TensorMap` objects each of the tensors passed in `tensors`
-        will be split into. If both `group_sizes_abs` and `group_sizes_rel`
-        are not specified, `n_groups` is used to split the data into ``n`` evenly
-        sized groups, to the nearest integer.
-    :param group_sizes_abs: an ordered `list` of `float` the absolute group
-        sizes to split each input TensorMap into. The sum of this list must be
-        <= the total number of unique indices present in the TensorMaps for the
-        chosen `axis` and `names`.
-    :param group_sizes_rel: an ordered `list` of `float` of the relative
-        group sizes to split each input TensorMap into. The sum of these float
-        values must <= 1.
+        will be split into. If `group_sizes` is none (default), `n_groups` is
+        used to split the data into ``n`` evenly sized groups according to the
+        unique metadata for the specified `axis` and `names`, to the nearest
+        integer.
+    :param group_sizes: an ordered `list` of `float` the group sizes to split
+        each input TensorMap into. A list of int will be interpreted as an
+        indication of the absolute group sizes, whereas a list of float as
+        indicating the relative sizes. For the former case, the sum of this list
+        must be <= the total number of unique indices present in the input
+        `tensors` for the chosen `axis` and `names`. In the latter, the sum of
+        this list must be <= 1.
     :param random_seed: an int that seeds the numpy random number generator.
         Used to control shuffling of the unique indices, which dictate the data
         that ends up in each of the split output tensors. If None, no shuffling
@@ -76,31 +76,34 @@ def split_data(
         set. If an integer != -1, shuffling is executed but with a random seed
         set to this value.
 
-    :return: list of list of :py:class:`TensorMap`. The ith element in the list
-        contains `n_groups` :py:class:`TensorMap` objects corresponding to the
-        split ith :py:class:`TensorMap` of the input list `tensors`.
-    :return: list of :py:class:`Labels` corresponding to the unique indices
-        according to the specified `axis` and `names` that are present in
-        each of the returned groups of :py:class:`TensorMap`. The length of this
-        list is `n_groups`.
+    :return split_tensors: list of list of :py:class:`TensorMap`. The ith
+        element in the list contains `n_groups` :py:class:`TensorMap` objects
+        corresponding to the split ith :py:class:`TensorMap` of the input list
+        `tensors`.
+    :return grouped_labels: list of :py:class:`Labels` corresponding to the
+        unique indices according to the specified `axis` and `names` that are
+        present in each of the returned groups of :py:class:`TensorMap`. The
+        length of this list is `n_groups`.
 
     Examples
     --------
 
     Split a TensorMap `tensor` into 2 new TensorMaps along the "samples" axis
-    for the "structure" metadata. Without specifying `group_sizes_abs` or
-    `group_sizes_rel`, the data will be split equally by structure index.
-    Without specifying `random_seed`, no shuffling of the structure indices will
-    occur and they will be grouped in lexigraphical order. For instance, if the
-    input tensor has structure indices 0 -> 9 (inclusive), the first new tensor
-    will contain only structure indices 0 -> 4 (inc.) and the second will
-    contain only 5 -> 9 (inc).
+    for the "structure" metadata. Without specifying `group_sizes`, the data
+    will be split equally by structure index. If the number of unique strutcure
+    indices present in the input data is not exactly divisible by `n_groups`,
+    the group sizes will be made to the nearest int. Without specifying
+    `random_seed`, no shuffling of the structure indices will occur and they
+    will be grouped in lexigraphical order. For instance, if the input tensor
+    has structure indices 0 -> 9 (inclusive), the first new tensor will contain
+    only structure indices 0 -> 4 (inc.) and the second will contain only 5 -> 9
+    (inc).
 
     .. code-block:: python
 
         from equisolve.utils import split_data
 
-        [[new_tensor_1, new_tensor_2]], grouped_idxs = split_data(
+        [[new_tensor_1, new_tensor_2]], grouped_labels = split_data(
             tensors=tensor,
             axis="samples",
             names=["structure"],
@@ -111,51 +114,79 @@ def split_data(
     data, with a relative 80:20 ratio. If both input and output tensors contain
     structure indices 0 -> 9 (inclusive), the `in_train` and `out_train` tensors
     will contain structure indices 0 -> 7 (inc.) and the `in_test` and
-    `out_test` tensors will contain structure indices 8 -> 9 (inc.).
+    `out_test` tensors will contain structure indices 8 -> 9 (inc.). As we want
+    to specify relative group sizes, we will pass `group_sizes` as a list of
+    float. Specifying the `random_seed` will shuffle the structure indices
+    before the groups are made.
 
     .. code-block:: python
 
         from equisolve.utils import split_data
 
-        [[in_train, in_test], [out_train, out_test]], grouped_idxs = split_data(
+        [[in_train, in_test], [out_train, out_test]], grouped_labels = split_data(
             tensors=[input, output],
             axis="samples",
             names=["structure"],
             n_groups=2,                  # for train-test split
-            group_sizes_rel=[0.8, 0.2],  # 80:20 train:test split
+            group_sizes=[0.8, 0.2],  # relative, a 80% 20% train-test split
             random_seed=100,
         )
 
     Split 2 tensors corresponding to input and output data into train, test, and
-    validation data. If input and output tensors have the same 100 structure
-    indices, we can split such that the train, test, and val tensors have 70,
-    20, and 10 structures in each, respectively. Specifying the `random_seed`
-    will shuffle the structure indices before they are grouped.
+    validation data. If input and output tensors have the same 10 structure
+    indices, we can split such that the train, test, and val tensors have 7,
+    2, and 1 structures in each, respectively. We want to specify absolute
+    group sizes, so will pass a list of int. Specifying the `random_seed` will
+    shuffle the structure indices before they are grouped.
 
     .. code-block:: python
 
+        import equistore
         from equisolve.utils import split_data
 
+        # Find the unique structure indices in the input tensor
+        unique_structure_indices = equistore.unique_metadata(
+            tensor=input, axis="samples", names=["structure"],
+        )
+        # They run from 0 -> 10 (inclusive)
+        unique_structure_indices
+        >>> Labels(
+            [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (8,), (9,)],
+            dtype=[('structure', '<i4')]
+        )
+        # Verify that the output has the same unique structure indices
+        assert unique_structure_indices == equistore.unique_metadata(
+            tensor=output, axis="samples", names=["structure"],
+        )
+        >>> True
+
+        # Split the data by structure index, with an abolute split of 7, 2, 1
+        # for the train, test, and validation tensors, respectively
         (
             [
                 [in_train, in_test, in_val],
                 [out_train, out_test, out_val]
             ]
-        ), grouped_idxs = split_data(
+        ), grouped_labels = split_data(
             tensors=[input, output],
             axis="samples",
             names=["structure"],
-            n_groups=3,                    # for train-test-validation
-            group_sizes_abs=[70, 20, 10],  # 70, 25, 10 train, test, val
+            n_groups=3,  # for train-test-validation
+            group_sizes=[7, 2, 1],  # absolute; 7, 2, 1 for train, test, val
             random_seed=100,
         )
+        # Inspect the grouped structure indices
+        grouped_labels
+        >>> [
+            Labels([(3,), (7,), (1,), (8,), (0,), (9,), (2,)], dtype=[('structure', '<i4')]),
+            Labels([(4,), (6,)], dtype=[('structure', '<i4')]),
+            Labels([(5,)], dtype=[('structure', '<i4')]),
+        ]
     """
-    # Check input args
+    # Check input args and parse `tensors` and `names` into lists
     tensors = [tensors] if isinstance(tensors, TensorMap) else tensors
     names = [names] if isinstance(names, str) else names
-    _check_args(
-        tensors, axis, names, n_groups, group_sizes_abs, group_sizes_rel, random_seed
-    )
+    _check_args(tensors, axis, names, n_groups, group_sizes, random_seed)
 
     # Get array of unique indices to split by for each tensor in `tensors`
     unique_idxs_list = [
@@ -169,18 +200,34 @@ def split_data(
     # Shuffle the unique indices according to the random seed
     _shuffle_indices(unique_idxs, random_seed)
 
+    # Must be at least as many unique indices as groups
+    n_indices = len(unique_idxs)
+    if n_indices < n_groups:
+        raise ValueError(
+            f"the number of groups specified ({n_groups}) is greater than the number of "
+            + f" unique metadata indices ({n_indices}) for the chosen axis {axis} and"
+            + f" names {names}: {unique_idxs}"
+        )
+
     # Get group sizes
-    group_sizes = _get_group_sizes(
-        n_groups, len(unique_idxs), group_sizes_abs, group_sizes_rel
-    )
+    group_sizes = _get_group_sizes(n_groups, len(unique_idxs), group_sizes)
+
+    # The sum of the absolute group sizes must be less than or equal to the
+    # number of unique indices
+    if n_indices < sum(group_sizes):
+        raise ValueError(
+            f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater than "
+            + f"the number of unique metadata indices ({n_indices}) for the chosen "
+            + f"axis {axis} and names {names}: {unique_idxs}"
+        )
 
     # Group the indices according to the group sizes
-    grouped_idxs = _group_indices(unique_idxs, group_sizes)
+    grouped_labels = _group_indices(unique_idxs, group_sizes)
 
     # Split each of the input TensorMaps
     split_tensors = []
     for i, tensor in enumerate(tensors):
-        split_tensors.append(equistore.split(tensor, axis, grouped_idxs))
+        split_tensors.append(equistore.split(tensor, axis, grouped_labels))
 
     # Check the indices of the split tensors. the jth TensorMap in every list of
     # split tensors should have equivalent unique indices.
@@ -191,52 +238,50 @@ def split_data(
         ]
         _check_labels_equivalent(unq_idxs_list)
 
-    return split_tensors, grouped_idxs
+    return split_tensors, grouped_labels
 
 
 def _shuffle_indices(indices: Labels, random_seed: Optional[int] = None):
     """
-    Shuffles the input Labels object `indices` according to the random seed.
-    If `random_seed=None`, not shuffling is performed and the indices are just
+    Shuffles the input Labels object `indices` according to the random seed. If
+    `random_seed=None`, not shuffling is performed and the indices are just
     returned. If -1, shuffling occurs but with no random seed set. If an integer
-    != -1, shuffling is executed but with a random seed set to this value.
+    != -1, shuffling is executed but with a random seed set to this value. There
+    is no return value, as the input `indices` is shuffled in place.
     """
     if random_seed is not None:  # shuffle
         if random_seed != -1:  # set a numpy random seed
             np.random.seed(random_seed)
         np.random.shuffle(indices)
-    return
 
 
 def _get_group_sizes(
     n_groups: int,
     n_indices: int,
-    group_sizes_abs: Optional[List[float]] = None,
-    group_sizes_rel: Optional[List[int]] = None,
+    group_sizes: Optional[Union[List[float], List[int]]] = None,
 ) -> np.ndarray:
     """
-    Parses the group sizes args from :py:func:`split_data` and returns an array
+    Parses the `group_sizes` arg from :py:func:`split_data` and returns an array
     of group sizes in absolute numbers.
-    :param n_groups: an int, the number of groups to split the data into
-    :param n_indices: an int, the number of unique indices present in the data
-        by which the data should be grouped.
-    :param group_sizes_abs:
+
+    :param n_groups: an int, the number of groups to split the data into :param
+        n_indices: an int, the number of unique indices present in the data by
+        which the data should be grouped.
+    :param n_indices: a :py:class:`int` for the number of unique indices present
+        in the input data for the specified `axis` and `names`.
+    :param group_sizes: a :py:class:`list` of :py:class:`float` or
+        :py:class:`int` indicating the absolute or relative group sizes,
+        respectively.
+
+    :return: a :py:class:`numpy.ndarray` of :py:class:`int` indicating the
+        absolute group sizes.
     """
-    # Must be at least as many unique indices as groups
-    if not (n_indices >= n_groups):
-        raise ValueError(
-            "you must specify at least as many groups as there are indices to split."
-        )
-    if group_sizes_abs is None:
-        if group_sizes_rel is None:
-            # Equally sized groups
-            group_sizes = np.array([1 / n_groups] * n_groups) * n_indices
-        else:
-            # Convert relative group sizes to absolute group sizes
-            group_sizes = np.array(group_sizes_rel) * n_indices
-    else:
-        # Already in absolute; just convert to an array
-        group_sizes = np.array(group_sizes_abs)
+    if group_sizes is None:  # equally sized groups
+        group_sizes = np.array([1 / n_groups] * n_groups) * n_indices
+    elif np.all([isinstance(size, int) for size in group_sizes]):  # absolute
+        group_sizes = np.array(group_sizes)
+    else:  # relative; list of float
+        group_sizes = np.array(group_sizes) * n_indices
 
     # The group sizes may not be integers. Use cascade rounding to round them
     # all to integers whilst attempting to minimize rounding error.
@@ -280,13 +325,13 @@ def _group_indices(indices: Labels, group_sizes: List[int]) -> Labels:
     `group_sizes`, and returned as a list of :py:class:`Labels` objects.
     """
     # Group the indices
-    grouped_idxs = []
+    grouped_labels = []
     prev_size = 0
     for i, size in enumerate(group_sizes):
-        grouped_idxs.append(indices[prev_size : prev_size + size])
+        grouped_labels.append(indices[prev_size : prev_size + size])
         prev_size += size
 
-    return grouped_idxs
+    return grouped_labels
 
 
 def _check_labels_equivalent(
@@ -299,45 +344,13 @@ def _check_labels_equivalent(
     if len(labels_list) <= 1:
         return
     # Define reference Labels object as the first in the list
-    try:
-        ref_labels = _searchable_labels(labels_list[0])
-    except AttributeError:
-        # Labels obj is already searchable
-        ref_labels = labels_list[0]
-    for label_i, test_label in enumerate(labels_list, start=1):
+    ref_labels = labels_list[0]
+    for label_i in range(1, len(labels_list)):
+        test_label = labels_list[label_i]
         if not np.array_equal(ref_labels, test_label):
             raise ValueError(
                 f"Labels objects in `labels_list` are not equivalent: {ref_labels} != {test_label}"
             )
-
-
-def _searchable_labels(labels: Labels):
-    """
-    Returns the input Labels object but after being used to construct a
-    TensorBlock, so that look-ups can be performed.
-    """
-    return TensorBlock(
-        values=np.full((len(labels), 1), 0.0),
-        samples=labels,
-        components=[],
-        properties=Labels(["p"], np.array([[0]], dtype=np.int32)),
-    ).samples
-
-
-def _labels_equal(a: Labels, b: Labels, exact_order: bool):
-    """
-    For 2 :py:class:`Labels` objects `a` and `b`, returns true if they are
-    exactly equivalent in names, values, and elemental positions. Assumes that
-    the Labels are already searchable, i.e. they belogn to a parent TensorBlock
-    or TensorMap.
-    """
-    # They can only be equivalent if the same length
-    if len(a) != len(b):
-        return False
-    if exact_order:
-        return np.all(np.array(a == b))
-    else:
-        return np.all([a_i in b for a_i in a])
 
 
 def _check_args(
@@ -345,9 +358,8 @@ def _check_args(
     axis: str,
     names: List[str],
     n_groups: int,
-    group_sizes_abs: List[int],
-    group_sizes_rel: List[float],
-    random_seed: int,
+    group_sizes: Optional[Union[List[float], List[int]]],
+    random_seed: Optional[int],
 ):
     """Checks the input args for :py:func:`split_data`."""
     # Check tensors passed as a list
@@ -359,9 +371,11 @@ def _check_args(
     for tensor in tensors:
         if not isinstance(tensor, TensorMap):
             raise TypeError(
-                f"`tensors` must bes a list of equistore `TensorMap`, got {type(tensors)}"
+                f"`tensors` must be a list of equistore `TensorMap`, got {type(tensors)}"
             )
     # Check axis
+    if not isinstance(axis, str):
+        raise TypeError(f"`axis` must be passed as a str, got {type(axis)}")
     if axis not in ["samples", "properties"]:
         raise ValueError(
             f"`axis` must be passsed as either 'samples' or 'properties', got {axis}"
@@ -369,50 +383,48 @@ def _check_args(
     # Check names
     if not isinstance(names, list):
         raise TypeError(f"`names` must be a list of str, got {type(names)}")
+    if not all([isinstance(name, str) for name in names]):
+        raise TypeError(f"`names` must be a list of str, got {type(names)}")
     for tensor in tensors:
-        for _, block in tensor:
-            tmp_names = (
-                block.samples.names if axis == "samples" else block.properties.names
-            )
-            for name in names:
-                if name not in tmp_names:
-                    raise ValueError(
-                        "each block of each `TensorMap` passed must have a samples "
-                        + "or properties name that matches the one passed in "
-                        + "`names`"
-                    )
+        tmp_names = tensor.sample_names if axis == "samples" else tensor.property_names
+        for name in names:
+            if name not in tmp_names:
+                raise ValueError(
+                    f"the passed `TensorMap` objects have {axis} names {tmp_names}"
+                    + f" that do not match the one passed in `names` {names}"
+                )
     # Check n_groups
     if not isinstance(n_groups, int):
         raise TypeError(f"`n_groups` must be passed as an int, got {type(n_groups)}")
-
-    # Check group_sizes_abs and group_sizes_rel
-    if group_sizes_abs is not None:
-        # Length is the same as n_groups
-        if len(group_sizes_abs) != n_groups:
-            raise ValueError(
-                "if specifying `group_sizes_abs` to split the tensors by, the list must"
-                + " have the same number of elements as indicated by `n_groups`"
+    if not n_groups > 0:
+        raise ValueError(f"`n_groups` must be greater than 0, got {n_groups}")
+    # Check group_sizes
+    if group_sizes is not None:
+        if not isinstance(group_sizes, list):
+            raise TypeError(
+                f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
             )
-        # group_sizes_rel isn't specified too
-        if group_sizes_rel is not None:
+        if len(group_sizes) != n_groups:
             raise ValueError(
-                "can only specify `group_sizes_abs` or `group_sizes_rel`, but not both"
+                "if specifying `group_sizes`, you must pass a list whose"
+                + " number of elements equal to `n_groups`"
             )
-    else:
-        if group_sizes_rel is not None:
-            # Length is the same as n_groups
-            if len(group_sizes_rel) != n_groups:
-                raise ValueError(
-                    "if specifying `group_sizes_rel` to split the tensors by, the list "
-                    + "must have the same number of elements as indicated by `n_groups`"
+        for size in group_sizes:
+            if not isinstance(size, (int, float)):
+                raise TypeError(
+                    f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
                 )
-            # Sum of the parts is 1
-            if np.sum(group_sizes_rel) > 1:
+            if not size > 0:
                 raise ValueError(
-                    "if specifying `group_sizes_rel`, the sum of the values in the list"
-                    + " must be <= 1"
+                    f"all elements of `group_sizes` must be greater than 0, got {group_sizes}"
+                )
+        if np.all([isinstance(size, float) for size in group_sizes]):
+            if np.sum(group_sizes) > 1:
+                raise ValueError(
+                    "if specifying `group_sizes` as a list of float, the sum of"
+                    + " the list must be less than or equal to 1"
                 )
     # Check random_seed
     if random_seed is not None:
         if not isinstance(random_seed, int):
-            raise TypeError("`random_seed` must be passed as an `int`")
+            raise TypeError(f"`random_seed` must be passed as an `int`, got {type(random_seed)}")

--- a/tests/equisolve_tests/utils/test_split_data.py
+++ b/tests/equisolve_tests/utils/test_split_data.py
@@ -214,7 +214,7 @@ def test_tensor_map_b():
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
 
 
-def check_no_overlap_indices(
+def check_no_intersection_indices_same_group(
     split_tensors: List[TensorMap], axis: str, names: List[str]
 ):
     """
@@ -222,23 +222,43 @@ def check_no_overlap_indices(
     the split tensors, for the specified axis and names.
     """
     # no overlap in indices between groups
-    for i in range(len(split_tensors[0])):
-        for j in range(i + 1, len(split_tensors[0])):
-            uniq_a = equistore.unique_metadata(
-                split_tensors[0][i],
-                axis,
-                names,
-            )
-            uniq_b = equistore.unique_metadata(
-                split_tensors[0][j],
-                axis,
-                names,
-            )
-            if np.any(np.isin(uniq_a, uniq_b)):
-                pytest.fail(f"{uniq_a} not equal to {uniq_b}")
+    for group in split_tensors:
+        for i in range(len(group)):
+            for j in range(i + 1, len(split_tensors[0])):
+                uniq_a = equistore.unique_metadata(
+                    split_tensors[0][i],
+                    axis,
+                    names,
+                )
+                uniq_b = equistore.unique_metadata(
+                    split_tensors[0][j],
+                    axis,
+                    names,
+                )
+                if np.any(np.isin(uniq_a, uniq_b)):
+                    pytest.fail(f"{uniq_a} not equal to {uniq_b}")
 
 
-def check_metadata(split_tensors: List[TensorMap], axis: str):
+def check_equivalent_indices_different_groups(
+    split_tensors: List[TensorMap], axis: str, names: List[str]
+):
+    """
+    Checks that the jth tensor in every list of split tensors has equivalent
+    unique metadata for the specified axis and names.
+    """
+    if len(split_tensors) == 1:
+        return
+    ref_list = split_tensors[0]
+    assert np.all([len(t) == len(ref_list) for t in split_tensors])
+    for i in range(1, len(split_tensors)):
+        check_list = split_tensors[i]
+        for j in range(len(ref_list)):
+            ref_uniq = equistore.unique_metadata(ref_list[j], axis, names)
+            check_uniq = equistore.unique_metadata(check_list[j], axis, names)
+            assert np.all(ref_uniq == check_uniq)
+
+
+def check_other_metadata(split_tensors: List[TensorMap], axis: str):
     """
     Checks that the components metadata are the same for the corresponding
     blocks in the split tensors. If the split axis is "samples", check the
@@ -292,7 +312,7 @@ class TestSplitData:
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)
         samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
-        target_grouped_idxs = [
+        target_grouped_labels = [
             Labels(
                 names=["samples"],
                 values=np.array([[s]]).reshape(-1, 1),
@@ -300,24 +320,27 @@ class TestSplitData:
             for s in samples_idxs
         ]
         axis, names, n_groups = "samples", "samples", 8
-        split_tensors, actual_grouped_idxs = split_data(
+        split_tensors, actual_grouped_labels = split_data(
             tensors=test_tensor_map,
             axis=axis,
             names=names,
             n_groups=n_groups,
         )
         # actual and target grouped indices are the same
-        assert_equal(actual_grouped_idxs, target_grouped_idxs)
+        assert_equal(actual_grouped_labels, target_grouped_labels)
         # 1 tensor in, so 1 list of tensors out
         assert_equal(len(split_tensors), 1)
         # in that list there should be 8 tensors
         assert_equal(len(split_tensors[0]), n_groups)
-        # check metadata along split axis
-        check_no_overlap_indices(split_tensors, axis, names)
+        # check metadata along split axis: no intersection between indices of
+        # TensorMaps in the same group, exact equivalence between indices of
+        # corresponding TensorMaps in different groups
+        check_no_intersection_indices_same_group(split_tensors, axis, names)
+        check_equivalent_indices_different_groups(split_tensors, axis, names)
         # check other metadata
-        check_metadata(split_tensors, axis)
+        check_other_metadata(split_tensors, axis)
         # check values
-        check_values(test_tensor_map, split_tensors, target_grouped_idxs)
+        check_values(test_tensor_map, split_tensors, target_grouped_labels)
 
     def test_split_data_with_shuffle(self, test_tensor_map, request):
         """
@@ -336,7 +359,7 @@ class TestSplitData:
         # Set the random seed to a different random seed
         np.random.seed(31415)
         # Define the target grouped indices
-        target_grouped_idxs = [
+        target_grouped_labels = [
             Labels(
                 names=["samples"],
                 values=np.array([[s]]).reshape(-1, 1),
@@ -345,35 +368,39 @@ class TestSplitData:
         ]
         # Split the data
         axis, names, n_groups = "samples", "samples", 8
-        split_tensors, actual_grouped_idxs = split_data(
-            tensors=test_tensor_map,
+        split_tensors, actual_grouped_labels = split_data(
+            tensors=[test_tensor_map, test_tensor_map],
             axis=axis,
             names=names,
             n_groups=n_groups,
             random_seed=random_seed,
         )
         # actual and target grouped indices are the same
-        assert_equal(actual_grouped_idxs, target_grouped_idxs)
+        assert_equal(actual_grouped_labels, target_grouped_labels)
         # 1 tensor in, so 1 list of tensors out
-        assert_equal(len(split_tensors), 1)
+        assert_equal(len(split_tensors), 2)
         # in that list there should be 8 tensors
         assert_equal(len(split_tensors[0]), n_groups)
-        # check metadata along split axis
-        check_no_overlap_indices(split_tensors, axis, names)
+        assert_equal(len(split_tensors[1]), n_groups)
+        # check metadata along split axis: no intersection between indices of
+        # TensorMaps in the same group, exact equivalence between indices of
+        # corresponding TensorMaps in different groups
+        check_no_intersection_indices_same_group(split_tensors, axis, names)
+        check_equivalent_indices_different_groups(split_tensors, axis, names)
         # check other metadata
-        check_metadata(split_tensors, axis)
+        check_other_metadata(split_tensors, axis)
         # check values
-        check_values(test_tensor_map, split_tensors, target_grouped_idxs)
+        check_values(test_tensor_map, split_tensors, target_grouped_labels)
 
-    def test_split_data_abs_rel_same_result(self, test_tensor_map, request):
+    def test_split_data_abs_rel_same_result_samples(self, test_tensor_map, request):
         """
-        Tests that splitting data using the `group_sizes_abs` and
-        `group_sizes_rel` args gives equivalent results.
+        Tests that splitting data using the `group_sizes` arg in absolute and
+        relative mode gives equivalent results.
         """
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)
         samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
-        target_grouped_idxs = [
+        target_grouped_labels = [
             Labels(
                 names=["samples"],
                 values=np.array([[0]]).reshape(-1, 1),
@@ -393,36 +420,81 @@ class TestSplitData:
         ]
         # Split the data using abs and rel group sizes
         axis, names, n_groups = "samples", "samples", 4
-        split_tensors_1, actual_grouped_idxs_1 = split_data(
+        split_tensors_1, actual_grouped_labels_1 = split_data(
             tensors=test_tensor_map,
             axis=axis,
             names=names,
             n_groups=n_groups,
-            group_sizes_abs=[1, 2, 4, 1],
+            group_sizes=[1, 2, 4, 1],  # absolute
         )
-        split_tensors_2, actual_grouped_idxs_2 = split_data(
+        split_tensors_2, actual_grouped_labels_2 = split_data(
             tensors=test_tensor_map,
             axis=axis,
             names=names,
             n_groups=n_groups,
-            group_sizes_rel=[1/8, 2/8, 4/8, 1/8],
+            group_sizes=[1 / 8, 2 / 8, 4 / 8, 1 / 8],  # relative
         )
-        assert_equal(target_grouped_idxs, actual_grouped_idxs_1)
-        assert_equal(actual_grouped_idxs_1, actual_grouped_idxs_2)
+        assert_equal(target_grouped_labels, actual_grouped_labels_1)
+        assert_equal(actual_grouped_labels_1, actual_grouped_labels_2)
         for i, j in zip(split_tensors_1[0], split_tensors_2[0]):
             assert equistore.equal(i, j)
 
-    def test_split_data_abs_rel_same_result(self, test_tensor_map, request):
+    def test_split_data_abs_rel_same_result_properties(self, test_tensor_map, request):
         """
-        Tests that splitting data using the `group_sizes_abs` and
-        `group_sizes_rel` args gives equivalent results.
+        Tests that splitting data using the `group_sizes` arg in absolute and
+        relative mode gives equivalent results.
+        """
+        # Get the parameterized TensorMap
+        test_tensor_map = request.getfixturevalue(test_tensor_map)
+        properties_idxs = np.array([0, 3, 4, 5])
+        target_grouped_labels = [
+            Labels(
+                names=["properties"],
+                values=np.array([[0]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["properties"],
+                values=np.array([[3, 4]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["properties"],
+                values=np.array([[5]]).reshape(-1, 1),
+            ),
+        ]
+        # Split the data using abs and rel group sizes
+        axis, names, n_groups = "properties", "properties", 3
+        split_tensors_1, actual_grouped_labels_1 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes=[1, 2, 1],  # absolute
+        )
+        split_tensors_2, actual_grouped_labels_2 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes=[1 / 4, 2 / 4, 1 / 4],  # relative
+        )
+        assert_equal(target_grouped_labels, actual_grouped_labels_1)
+        assert_equal(actual_grouped_labels_1, actual_grouped_labels_2)
+        for i, j in zip(split_tensors_1[0], split_tensors_2[0]):
+            assert equistore.equal(i, j)
+
+    def test_split_data_abs_rel_same_result_less_than_n(self, test_tensor_map, request):
+        """
+        Tests that splitting data using the `group_sizes` arg in abs and rel
+        modes gives equivalent results. Completes for passing these as summing
+        to less than the number of unique indices (in the case of abs mode) or
+        less than 1 (in the case of rel mode).
         """
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)
         # There are 8 unique structure idxs in total
         samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
         # Split only the first 7 of these
-        target_grouped_idxs = [
+        target_grouped_labels = [
             Labels(
                 names=["samples"],
                 values=np.array([[0]]).reshape(-1, 1),
@@ -438,25 +510,325 @@ class TestSplitData:
         ]
         # Split the data using abs and rel group sizes
         axis, names, n_groups = "samples", "samples", 3
-        split_tensors_1, actual_grouped_idxs_1 = split_data(
+        split_tensors_1, actual_grouped_labels_1 = split_data(
             tensors=test_tensor_map,
             axis=axis,
             names=names,
             n_groups=n_groups,
-            group_sizes_abs=[1, 2, 4],  # adds up to 7
+            group_sizes=[1, 2, 4],  # adds up to 7
         )
-        split_tensors_2, actual_grouped_idxs_2 = split_data(
+        split_tensors_2, actual_grouped_labels_2 = split_data(
             tensors=test_tensor_map,
             axis=axis,
             names=names,
             n_groups=n_groups,
-            group_sizes_rel=[1/8, 2/8, 4/8],  # adds up to 7/8
+            group_sizes=[1 / 8, 2 / 8, 4 / 8],  # adds up to 7/8
         )
-        assert_equal(target_grouped_idxs, actual_grouped_idxs_1)
-        assert_equal(actual_grouped_idxs_1, actual_grouped_idxs_2)
+        assert_equal(target_grouped_labels, actual_grouped_labels_1)
+        assert_equal(actual_grouped_labels_1, actual_grouped_labels_2)
         for i, j in zip(split_tensors_1[0], split_tensors_2[0]):
             assert equistore.equal(i, j)
 
 
-# class TestSplitDataErrors:
-#     def test_split_data_error(self):
+    def test_split_data_unequal_groups(self, test_tensor_map, request):
+        """
+        Tests that splitting data into equal groups using only the `n_groups`
+        splits as expected when the number of unique indices is not divisible
+        by `n_groups`. In this case, there are 8 unique structure idxs in the
+        test tensor maps, 
+        """
+        # Get the parameterized TensorMap
+        test_tensor_map = request.getfixturevalue(test_tensor_map)
+        # There are 8 unique structure idxs in total
+        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        # Split only the first 7 of these
+        target_grouped_labels = [
+            Labels(
+                names=["samples"],
+                values=np.array([[0]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["samples"],
+                values=np.array([[1, 2]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["samples"],
+                values=np.array([[3, 4, 5, 6]]).reshape(-1, 1),
+            ),
+        ]
+        # Split the data using abs and rel group sizes
+        axis, names, n_groups = "samples", "samples", 3
+        split_tensors_1, actual_grouped_labels_1 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes=[1, 2, 4],  # adds up to 7
+        )
+        split_tensors_2, actual_grouped_labels_2 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes=[1 / 8, 2 / 8, 4 / 8],  # adds up to 7/8
+        )
+        assert_equal(target_grouped_labels, actual_grouped_labels_1)
+        assert_equal(actual_grouped_labels_1, actual_grouped_labels_2)
+        for i, j in zip(split_tensors_1[0], split_tensors_2[0]):
+            assert equistore.equal(i, j)
+
+
+class TestSplitDataErrors:
+    def test_split_data_errors_arg_tensors(self, test_tensor_map_a):
+        """
+        Checks for exceptions on the `tensors` arg.
+        """
+        # Not passing a TensorMap
+        with pytest.raises(TypeError) as e:
+            tensors = 5
+            split_data(
+                tensors=tensors,
+                axis="samples",
+                names="samples",
+                n_groups=3,
+            )
+        assert (
+            str(e.value)
+            == f"`tensors` must be a list of equistore `TensorMap`, got {type(tensors)}"
+        )
+        # Not passing a list of TensorMap
+        with pytest.raises(TypeError) as e:
+            tensors = [test_tensor_map_a, 3]
+            split_data(
+                tensors=tensors,
+                axis="samples",
+                names="samples",
+                n_groups=3,
+            )
+        assert (
+            str(e.value)
+            == f"`tensors` must be a list of equistore `TensorMap`, got {type(tensors)}"
+        )
+        # Passing just a TensorMap, not in a list is ok
+        split_data(
+            tensors=test_tensor_map_a,
+            axis="samples",
+            names="samples",
+            n_groups=3,
+        )
+
+    def test_split_data_errors_arg_axis(self, test_tensor_map_a):
+        """
+        Checks for exceptions on the `axis` arg.
+        """
+        # Passing axis not as a string
+        with pytest.raises(TypeError) as e:
+            axis = 3.14
+            split_data(
+                tensors=test_tensor_map_a,
+                axis=axis,
+                names="samples",
+                n_groups=3,
+            )
+        assert str(e.value) == f"`axis` must be passed as a str, got {type(axis)}"
+        # Passing axis as an incorrect str
+        with pytest.raises(ValueError) as e:
+            axis = "not_samples"
+            split_data(
+                tensors=test_tensor_map_a,
+                axis=axis,
+                names="samples",
+                n_groups=3,
+            )
+        assert (
+            str(e.value)
+            == f"`axis` must be passsed as either 'samples' or 'properties', got {axis}"
+        )
+
+    def test_split_data_errors_arg_names(self, test_tensor_map_a):
+        """
+        Checks for exceptions on the `names` arg.
+        """
+        # Passing axis not as a list
+        with pytest.raises(TypeError) as e:
+            names = 3.14
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="samples",
+                names=names,
+                n_groups=3,
+            )
+        assert str(e.value) == f"`names` must be a list of str, got {type(names)}"
+        # Passing axis not as a list
+        with pytest.raises(TypeError) as e:
+            names = [3.14, 6.28]
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="samples",
+                names=names,
+                n_groups=3,
+            )
+        assert str(e.value) == f"`names` must be a list of str, got {type(names)}"
+        # Passing non-existent names
+        with pytest.raises(ValueError) as e:
+            axis = "samples"
+            names = ["not_samples"]
+            split_data(
+                tensors=test_tensor_map_a,
+                axis=axis,
+                names=names,
+                n_groups=3,
+            )
+        tmp_names = ("samples",)
+        assert str(e.value) == (
+            f"the passed `TensorMap` objects have {axis} names {tmp_names}"
+            + f" that do not match the one passed in `names` {names}"
+        )
+
+    def test_split_data_errors_arg_n_groups(self, test_tensor_map_a):
+        """
+        Checks for exceptions on the `n_groups` arg.
+        """
+        # Passing n_groups not as an int
+        with pytest.raises(TypeError) as e:
+            n_groups = 3.14
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="samples",
+                names="samples",
+                n_groups=n_groups,
+            )
+        assert (
+            str(e.value) == f"`n_groups` must be passed as an int, got {type(n_groups)}"
+        )
+        # Passing n_groups as a negative int
+        with pytest.raises(ValueError) as e:
+            n_groups = -3
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="samples",
+                names="samples",
+                n_groups=n_groups,
+            )
+        assert str(e.value) == f"`n_groups` must be greater than 0, got {n_groups}"
+
+    def test_split_data_errors_arg_group_sizes(self, test_tensor_map_a):
+        """
+        Checks for exceptions on the `group_sizes` arg.
+        """
+        # Passing group_sizes not as a list
+        with pytest.raises(TypeError) as e:
+            group_sizes = 3.14
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="samples",
+                names="samples",
+                n_groups=3,
+                group_sizes=group_sizes,
+            )
+        assert (
+            str(e.value)
+            == f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
+        )
+        # Passing group_sizes not as a list of int or float
+        with pytest.raises(TypeError) as e:
+            group_sizes = [3.14, "3.14", "6.28"]
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="properties",
+                names="properties",
+                n_groups=3,
+                group_sizes=group_sizes,
+            )
+        assert (
+            str(e.value)
+            == f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
+        )
+        # Passing group_sizes as a list of negative int or float
+        with pytest.raises(ValueError) as e:
+            group_sizes = [-3, 3]
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="samples",
+                names="samples",
+                n_groups=2,
+                group_sizes=group_sizes,
+            )
+        assert (
+            str(e.value)
+            == f"all elements of `group_sizes` must be greater than 0, got {group_sizes}"
+        )
+        # Passing group_sizes as a list of float whose sum is > 1
+        with pytest.raises(ValueError) as e:
+            group_sizes = [0.7, 0.4]
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="properties",
+                names="properties",
+                n_groups=2,
+                group_sizes=group_sizes,
+            )
+        assert (
+            str(e.value)
+            == "if specifying `group_sizes` as a list of float, the sum of"
+            + " the list must be less than or equal to 1"
+        )
+        # Passing group_sizes as a list of int whose sum is greater than the
+        # number of unique properties
+        with pytest.raises(ValueError) as e:
+            group_sizes = [3, 3]
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="properties",
+                names="properties",
+                n_groups=2,
+                group_sizes=group_sizes,
+            )
+        unique_idxs = equistore.unique_metadata(
+            test_tensor_map_a, "properties", "properties"
+        )
+        assert (
+            str(e.value)
+            == f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater than "
+            + f"the number of unique metadata indices ({4}) for the chosen "
+            + f"axis {'properties'} and names {['properties']}: {unique_idxs}"
+        )
+        # Passing group_sizes as a list of a single int which is greater than
+        # the number of unique properties
+        with pytest.raises(ValueError) as e:
+            group_sizes = [1000]
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="properties",
+                names="properties",
+                n_groups=1,
+                group_sizes=group_sizes,
+            )
+        unique_idxs = equistore.unique_metadata(
+            test_tensor_map_a, "properties", "properties"
+        )
+        assert (
+            str(e.value)
+            == f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater than "
+            + f"the number of unique metadata indices ({4}) for the chosen "
+            + f"axis {'properties'} and names {['properties']}: {unique_idxs}"
+        )
+
+    def test_split_data_errors_random_seed(self, test_tensor_map_a):
+        """
+        Checks for exceptions on the `random_seed` arg.
+        """
+        # Passing random_seed not as an int
+        with pytest.raises(TypeError) as e:
+            random_seed = 3.14
+            split_data(
+                tensors=test_tensor_map_a,
+                axis="samples",
+                names="samples",
+                n_groups=3,
+                random_seed=random_seed,
+            )
+        assert (
+            str(e.value)
+            == f"`random_seed` must be passed as an `int`, got {type(random_seed)}"
+        )

--- a/tests/equisolve_tests/utils/test_split_data.py
+++ b/tests/equisolve_tests/utils/test_split_data.py
@@ -1,0 +1,240 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2023 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the BSD 3-Clause "New" or "Revised" License
+# SPDX-License-Identifier: BSD-3-Clause
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+import pytest
+
+from equistore import io, Labels, TensorBlock, TensorMap
+from equisolve.utils import split_data
+
+
+class TestSplitData:
+    def set_up(self):
+        self.tensor_a = test_tensor_map_a()
+        self.tensor_b = test_tensor_map_b()
+
+    def test_split_data_no_shuffle(self):
+        """
+        Tests splitting a single TensorMap along "samples" axis, using sample
+        name "samples", with no shuffling of the indices.
+        """
+        # Passing ``tensors`` and ``names`` not in a list shoudl not throw an
+        # error. Passing ``n_groups=8`` should split into 8 even groups
+        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        target_grouped_idxs = [
+            Labels(
+                names=["samples"],
+                values=np.array([[s]]).reshape(-1, 1),
+            )
+            for s in samples_idxs
+        ]
+        split_tensors, actual_grouped_idxs = split_data(
+            tensors=self.tensor_a,
+            axis="samples",
+            names="samples",
+            n_groups=-1,
+        )
+        # for i in range(len(target_grouped_idxs)):
+
+        # TODO: Intersection between all groups of indices is zero
+
+
+def test_tensor_map_a():
+    """
+    Create a dummy tensor map to be used in tests. This is the same one as the
+    tensor map used in `tensor.rs` tests.
+    """
+    block_1 = TensorBlock(
+        values=np.full((3, 1, 1), 1.0),
+        samples=Labels(["samples"], np.array([[0], [2], [4]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_1.add_gradient(
+        "parameter",
+        samples=Labels(
+            ["sample", "parameter"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+        ),
+        data=np.full((2, 1, 1), 11.0),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+    )
+
+    block_2 = TensorBlock(
+        values=np.full((3, 1, 3), 2.0),
+        samples=Labels(["samples"], np.array([[0], [1], [3]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+        properties=Labels(["properties"], np.array([[3], [4], [5]], dtype=np.int32)),
+    )
+    block_2.add_gradient(
+        "parameter",
+        data=np.full((3, 1, 3), 12.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[0, -2], [0, 3], [2, -2]], dtype=np.int32),
+        ),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+    )
+
+    block_3 = TensorBlock(
+        values=np.full((4, 3, 1), 3.0),
+        samples=Labels(
+            ["samples"],
+            np.array([[0], [3], [6], [8]], dtype=np.int32),
+        ),
+        components=[
+            Labels(
+                ["components"],
+                np.array([[0], [1], [2]], dtype=np.int32),
+            )
+        ],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_3.add_gradient(
+        "parameter",
+        data=np.full((1, 3, 1), 13.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[1, -2]], dtype=np.int32),
+        ),
+        components=[
+            Labels(
+                ["components"],
+                np.array([[0], [1], [2]], dtype=np.int32),
+            )
+        ],
+    )
+
+    block_4 = TensorBlock(
+        values=np.full((4, 3, 1), 4.0),
+        samples=Labels(["samples"], np.array([[0], [1], [2], [5]], dtype=np.int32)),
+        components=[
+            Labels(
+                ["components"],
+                np.array([[0], [1], [2]], dtype=np.int32),
+            )
+        ],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_4.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 14.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[0, 1], [3, 3]], dtype=np.int32),
+        ),
+        components=[
+            Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32)),
+        ],
+    )
+
+    keys = Labels(
+        names=["key_1", "key_2"],
+        values=np.array([[0, 0], [1, 0], [2, 2], [2, 3]], dtype=np.int32),
+    )
+
+    return TensorMap(keys, [block_1, block_2, block_3, block_4])
+
+
+def test_tensor_map_b():
+    """
+    Create a dummy tensor map to be used in tests. This is the same one as the
+    tensor map used in `tensor.rs` tests.
+    """
+    block_1 = TensorBlock(
+        values=np.full((3, 1, 1), 101.0),
+        samples=Labels(["samples"], np.array([[0], [2], [4]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_1.add_gradient(
+        "parameter",
+        samples=Labels(
+            ["sample", "parameter"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+        ),
+        data=np.full((2, 1, 1), 111.0),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+    )
+
+    block_2 = TensorBlock(
+        values=np.full((3, 1, 3), 102.0),
+        samples=Labels(["samples"], np.array([[0], [1], [3]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+        properties=Labels(
+            ["properties"],
+            np.array([[3], [4], [5]], dtype=np.int32),
+        ),
+    )
+    block_2.add_gradient(
+        "parameter",
+        data=np.full((3, 1, 3), 112.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[0, -2], [0, 3], [2, -2]], dtype=np.int32),
+        ),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+    )
+
+    block_3 = TensorBlock(
+        values=np.full((4, 3, 1), 103.0),
+        samples=Labels(
+            ["samples"],
+            np.array([[0], [3], [6], [8]], dtype=np.int32),
+        ),
+        components=[
+            Labels(
+                ["components"],
+                np.array([[0], [1], [2]], dtype=np.int32),
+            )
+        ],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_3.add_gradient(
+        "parameter",
+        data=np.full((1, 3, 1), 113.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[1, -2]], dtype=np.int32),
+        ),
+        components=[
+            Labels(
+                ["components"],
+                np.array([[0], [1], [2]], dtype=np.int32),
+            )
+        ],
+    )
+
+    block_4 = TensorBlock(
+        values=np.full((4, 3, 1), 104.0),
+        samples=Labels(["samples"], np.array([[0], [1], [2], [5]], dtype=np.int32)),
+        components=[
+            Labels(
+                ["components"],
+                np.array([[0], [1], [2]], dtype=np.int32),
+            )
+        ],
+        properties=Labels(
+            ["properties"],
+            np.array([[0]], dtype=np.int32),
+        ),
+    )
+    block_4.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 114.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[0, 1], [3, 3]], dtype=np.int32),
+        ),
+        components=[Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32))],
+    )
+
+    keys = Labels(
+        names=["key_1", "key_2"],
+        values=np.array([[0, 0], [1, 0], [2, 2], [2, 3]], dtype=np.int32),
+    )
+
+    return TensorMap(keys, [block_1, block_2, block_3, block_4])

--- a/tests/equisolve_tests/utils/test_split_data.py
+++ b/tests/equisolve_tests/utils/test_split_data.py
@@ -10,8 +10,8 @@ from typing import List
 import equistore
 import numpy as np
 import pytest
-from equistore import Labels, TensorBlock, TensorMap, io
-from numpy.testing import assert_allclose, assert_equal
+from equistore import Labels, TensorBlock, TensorMap
+from numpy.testing import assert_equal
 
 from equisolve.utils import split_data
 
@@ -399,7 +399,7 @@ class TestSplitData:
         """
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)
-        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        # There are 8 unique samples indices - [0, 1, 2, 3, 4, 5, 6, 8]
         target_grouped_labels = [
             Labels(
                 names=["samples"],
@@ -446,7 +446,7 @@ class TestSplitData:
         """
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)
-        properties_idxs = np.array([0, 3, 4, 5])
+        # There are 4 unique properties indices - [0, 3, 4, 5]
         target_grouped_labels = [
             Labels(
                 names=["properties"],
@@ -491,8 +491,7 @@ class TestSplitData:
         """
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)
-        # There are 8 unique structure idxs in total
-        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        # There are 8 unique structure idxs in total: [0, 1, 2, 3, 4, 5, 6, 8]
         # Split only the first 7 of these
         target_grouped_labels = [
             Labels(
@@ -538,8 +537,7 @@ class TestSplitData:
         """
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)
-        # There are 8 unique structure idxs in total
-        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        # There are 8 unique structure idxs in total: [0, 1, 2, 3, 4, 5, 6, 8]
         # Split only the first 7 of these
         target_grouped_labels = [
             Labels(
@@ -727,7 +725,8 @@ class TestSplitDataErrors:
             )
         assert (
             str(e.value)
-            == f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
+            == "`group_sizes` must be passed as a list of float or int,"
+            + f" got {type(group_sizes)}"
         )
         # Passing group_sizes not as a list of int or float
         with pytest.raises(TypeError) as e:
@@ -741,7 +740,8 @@ class TestSplitDataErrors:
             )
         assert (
             str(e.value)
-            == f"`group_sizes` must be passed as a list of float or int, got {type(group_sizes)}"
+            == "`group_sizes` must be passed as a list of float or int,"
+            + f" got {type(group_sizes)}"
         )
         # Passing group_sizes as a list of negative int or float
         with pytest.raises(ValueError) as e:
@@ -755,7 +755,8 @@ class TestSplitDataErrors:
             )
         assert (
             str(e.value)
-            == f"all elements of `group_sizes` must be greater than 0, got {group_sizes}"
+            == "all elements of `group_sizes` must be greater than 0,"
+            + f" got {group_sizes}"
         )
         # Passing group_sizes as a list of float whose sum is > 1
         with pytest.raises(ValueError) as e:
@@ -788,8 +789,8 @@ class TestSplitDataErrors:
         )
         assert (
             str(e.value)
-            == f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater than "
-            + f"the number of unique metadata indices ({4}) for the chosen "
+            == f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater"
+            + f" than the number of unique metadata indices ({4}) for the chosen "
             + f"axis {'properties'} and names {['properties']}: {unique_idxs}"
         )
         # Passing group_sizes as a list of a single int which is greater than
@@ -808,8 +809,8 @@ class TestSplitDataErrors:
         )
         assert (
             str(e.value)
-            == f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater than "
-            + f"the number of unique metadata indices ({4}) for the chosen "
+            == f"the sum of the absolute group sizes ({sum(group_sizes)}) is greater"
+            + f" than the number of unique metadata indices ({4}) for the chosen "
             + f"axis {'properties'} and names {['properties']}: {unique_idxs}"
         )
 

--- a/tests/equisolve_tests/utils/test_split_data.py
+++ b/tests/equisolve_tests/utils/test_split_data.py
@@ -7,12 +7,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from typing import List
 
-import numpy as np
-from numpy.testing import assert_allclose, assert_equal
-import pytest
-
 import equistore
-from equistore import io, Labels, TensorBlock, TensorMap
+import numpy as np
+import pytest
+from equistore import Labels, TensorBlock, TensorMap, io
+from numpy.testing import assert_allclose, assert_equal
+
 from equisolve.utils import split_data
 
 
@@ -529,13 +529,12 @@ class TestSplitData:
         for i, j in zip(split_tensors_1[0], split_tensors_2[0]):
             assert equistore.equal(i, j)
 
-
     def test_split_data_unequal_groups(self, test_tensor_map, request):
         """
         Tests that splitting data into equal groups using only the `n_groups`
         splits as expected when the number of unique indices is not divisible
         by `n_groups`. In this case, there are 8 unique structure idxs in the
-        test tensor maps, 
+        test tensor maps,
         """
         # Get the parameterized TensorMap
         test_tensor_map = request.getfixturevalue(test_tensor_map)

--- a/tests/equisolve_tests/utils/test_split_data.py
+++ b/tests/equisolve_tests/utils/test_split_data.py
@@ -5,45 +5,18 @@
 #
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
+from typing import List
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pytest
 
+import equistore
 from equistore import io, Labels, TensorBlock, TensorMap
 from equisolve.utils import split_data
 
 
-class TestSplitData:
-    def set_up(self):
-        self.tensor_a = test_tensor_map_a()
-        self.tensor_b = test_tensor_map_b()
-
-    def test_split_data_no_shuffle(self):
-        """
-        Tests splitting a single TensorMap along "samples" axis, using sample
-        name "samples", with no shuffling of the indices.
-        """
-        # Passing ``tensors`` and ``names`` not in a list shoudl not throw an
-        # error. Passing ``n_groups=8`` should split into 8 even groups
-        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
-        target_grouped_idxs = [
-            Labels(
-                names=["samples"],
-                values=np.array([[s]]).reshape(-1, 1),
-            )
-            for s in samples_idxs
-        ]
-        split_tensors, actual_grouped_idxs = split_data(
-            tensors=self.tensor_a,
-            axis="samples",
-            names="samples",
-            n_groups=-1,
-        )
-        # for i in range(len(target_grouped_idxs)):
-
-        # TODO: Intersection between all groups of indices is zero
-
-
+@pytest.fixture
 def test_tensor_map_a():
     """
     Create a dummy tensor map to be used in tests. This is the same one as the
@@ -140,6 +113,7 @@ def test_tensor_map_a():
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
 
 
+@pytest.fixture
 def test_tensor_map_b():
     """
     Create a dummy tensor map to be used in tests. This is the same one as the
@@ -238,3 +212,251 @@ def test_tensor_map_b():
     )
 
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
+
+
+def check_no_overlap_indices(
+    split_tensors: List[TensorMap], axis: str, names: List[str]
+):
+    """
+    Checks that there is no overlap (i.e. intersection) between the indices in
+    the split tensors, for the specified axis and names.
+    """
+    # no overlap in indices between groups
+    for i in range(len(split_tensors[0])):
+        for j in range(i + 1, len(split_tensors[0])):
+            uniq_a = equistore.unique_metadata(
+                split_tensors[0][i],
+                axis,
+                names,
+            )
+            uniq_b = equistore.unique_metadata(
+                split_tensors[0][j],
+                axis,
+                names,
+            )
+            if np.any(np.isin(uniq_a, uniq_b)):
+                pytest.fail(f"{uniq_a} not equal to {uniq_b}")
+
+
+def check_metadata(split_tensors: List[TensorMap], axis: str):
+    """
+    Checks that the components metadata are the same for the corresponding
+    blocks in the split tensors. If the split axis is "samples", check the
+    properties are the same, otherwise check the samples are the same.
+    """
+    ref_tensor = split_tensors[0][0]
+    for i in range(1, len(split_tensors[0])):
+        for key in ref_tensor.keys:
+            ref_block = ref_tensor[key]
+            check_block = split_tensors[0][i][key]
+            # check samples the same if splitting on properties
+            if axis == "samples":
+                assert np.all(ref_block.properties == check_block.properties)
+            else:
+                assert np.all(ref_block.samples == check_block.samples)
+            # components are the same
+            for c_i in range(len(ref_block.components)):
+                if not np.all(ref_block.components[c_i] == check_block.components[c_i]):
+                    pytest.fail(
+                        f"components don't match: {ref_block.components[c_i]}"
+                        + f" != {check_block.components[c_i]}"
+                    )
+
+
+def check_values(
+    original_tensor: TensorMap,
+    split_tensors: List[TensorMap],
+    target_indices: List[Labels],
+):
+    """
+    Checks that the block values have been sliced correctly.
+    """
+    for i, indices in enumerate(target_indices):
+        ref_tensor = equistore.slice(original_tensor, samples=indices)
+        for key, ref_block in ref_tensor:
+            check_block = split_tensors[0][i][key]
+            if not np.all(ref_block.values == check_block.values):
+                pytest.fail(f"Expected {ref_block.values}, got {check_block.values}")
+
+
+@pytest.mark.parametrize(
+    "test_tensor_map",
+    ["test_tensor_map_a", "test_tensor_map_b"],
+)
+class TestSplitData:
+    def test_split_data_no_shuffle(self, test_tensor_map, request):
+        """
+        Tests splitting a single TensorMap along "samples" axis, using sample
+        name "samples", with no shuffling of the indices.
+        """
+        # Get the parameterized TensorMap
+        test_tensor_map = request.getfixturevalue(test_tensor_map)
+        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        target_grouped_idxs = [
+            Labels(
+                names=["samples"],
+                values=np.array([[s]]).reshape(-1, 1),
+            )
+            for s in samples_idxs
+        ]
+        axis, names, n_groups = "samples", "samples", 8
+        split_tensors, actual_grouped_idxs = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+        )
+        # actual and target grouped indices are the same
+        assert_equal(actual_grouped_idxs, target_grouped_idxs)
+        # 1 tensor in, so 1 list of tensors out
+        assert_equal(len(split_tensors), 1)
+        # in that list there should be 8 tensors
+        assert_equal(len(split_tensors[0]), n_groups)
+        # check metadata along split axis
+        check_no_overlap_indices(split_tensors, axis, names)
+        # check other metadata
+        check_metadata(split_tensors, axis)
+        # check values
+        check_values(test_tensor_map, split_tensors, target_grouped_idxs)
+
+    def test_split_data_with_shuffle(self, test_tensor_map, request):
+        """
+        Tests splitting a single TensorMap along "samples" axis, using sample
+        name "samples", with shuffling of the indices.
+        """
+        # Get the parameterized TensorMap
+        test_tensor_map = request.getfixturevalue(test_tensor_map)
+        # Define the sample indices
+        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        # Copy and shuffle the indices using a seed
+        shuffled_sample_idxs = np.array(samples_idxs, copy=True)
+        random_seed = 1
+        np.random.seed(random_seed)
+        np.random.shuffle(shuffled_sample_idxs)
+        # Set the random seed to a different random seed
+        np.random.seed(31415)
+        # Define the target grouped indices
+        target_grouped_idxs = [
+            Labels(
+                names=["samples"],
+                values=np.array([[s]]).reshape(-1, 1),
+            )
+            for s in shuffled_sample_idxs
+        ]
+        # Split the data
+        axis, names, n_groups = "samples", "samples", 8
+        split_tensors, actual_grouped_idxs = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            random_seed=random_seed,
+        )
+        # actual and target grouped indices are the same
+        assert_equal(actual_grouped_idxs, target_grouped_idxs)
+        # 1 tensor in, so 1 list of tensors out
+        assert_equal(len(split_tensors), 1)
+        # in that list there should be 8 tensors
+        assert_equal(len(split_tensors[0]), n_groups)
+        # check metadata along split axis
+        check_no_overlap_indices(split_tensors, axis, names)
+        # check other metadata
+        check_metadata(split_tensors, axis)
+        # check values
+        check_values(test_tensor_map, split_tensors, target_grouped_idxs)
+
+    def test_split_data_abs_rel_same_result(self, test_tensor_map, request):
+        """
+        Tests that splitting data using the `group_sizes_abs` and
+        `group_sizes_rel` args gives equivalent results.
+        """
+        # Get the parameterized TensorMap
+        test_tensor_map = request.getfixturevalue(test_tensor_map)
+        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        target_grouped_idxs = [
+            Labels(
+                names=["samples"],
+                values=np.array([[0]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["samples"],
+                values=np.array([[1, 2]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["samples"],
+                values=np.array([[3, 4, 5, 6]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["samples"],
+                values=np.array([[8]]).reshape(-1, 1),
+            ),
+        ]
+        # Split the data using abs and rel group sizes
+        axis, names, n_groups = "samples", "samples", 4
+        split_tensors_1, actual_grouped_idxs_1 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes_abs=[1, 2, 4, 1],
+        )
+        split_tensors_2, actual_grouped_idxs_2 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes_rel=[1/8, 2/8, 4/8, 1/8],
+        )
+        assert_equal(target_grouped_idxs, actual_grouped_idxs_1)
+        assert_equal(actual_grouped_idxs_1, actual_grouped_idxs_2)
+        for i, j in zip(split_tensors_1[0], split_tensors_2[0]):
+            assert equistore.equal(i, j)
+
+    def test_split_data_abs_rel_same_result(self, test_tensor_map, request):
+        """
+        Tests that splitting data using the `group_sizes_abs` and
+        `group_sizes_rel` args gives equivalent results.
+        """
+        # Get the parameterized TensorMap
+        test_tensor_map = request.getfixturevalue(test_tensor_map)
+        # There are 8 unique structure idxs in total
+        samples_idxs = np.array([0, 1, 2, 3, 4, 5, 6, 8])
+        # Split only the first 7 of these
+        target_grouped_idxs = [
+            Labels(
+                names=["samples"],
+                values=np.array([[0]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["samples"],
+                values=np.array([[1, 2]]).reshape(-1, 1),
+            ),
+            Labels(
+                names=["samples"],
+                values=np.array([[3, 4, 5, 6]]).reshape(-1, 1),
+            ),
+        ]
+        # Split the data using abs and rel group sizes
+        axis, names, n_groups = "samples", "samples", 3
+        split_tensors_1, actual_grouped_idxs_1 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes_abs=[1, 2, 4],  # adds up to 7
+        )
+        split_tensors_2, actual_grouped_idxs_2 = split_data(
+            tensors=test_tensor_map,
+            axis=axis,
+            names=names,
+            n_groups=n_groups,
+            group_sizes_rel=[1/8, 2/8, 4/8],  # adds up to 7/8
+        )
+        assert_equal(target_grouped_idxs, actual_grouped_idxs_1)
+        assert_equal(actual_grouped_idxs_1, actual_grouped_idxs_2)
+        for i, j in zip(split_tensors_1[0], split_tensors_2[0]):
+            assert equistore.equal(i, j)
+
+
+# class TestSplitDataErrors:
+#     def test_split_data_error(self):

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ deps =
     hypothesis
     pytest
     pytest-cov
-    rascaline @ https://github.com/luthaf/rascaline/archive/3a7492e.zip
 # before running the tests erases any prerecord of coverage
 commands_pre =
     coverage erase


### PR DESCRIPTION
This function wraps the `split` and `unique_metadata` operations in equistore, allowing users to split multiple TensorMaps according to named indices (randomly shuffled or otherwise) along a given TensorBlock axis. It is high-level enough such that it does not require the specification of any Labels objects.

**Example Usage**

```py
import equistore.io
from equisolve.utils import split_data

# Load input and output TensorMaps
input = equistore.io("/path/to/input/tensormap/")
output = equistore.io("/path/to/output/tensormap/")

[[in_train, in_test], [out_train, out_test]], grouped_idxs = split_data(
            tensors=[input, output],
            axis="samples", 
            names=["structure"],
            n_groups=2,  # for train-test split
            group_sizes_rel=[0.8, 0.2],  # 80:20 train:test split
            random_seed=100,
        )
```

The function returns the split tensors, where each respective tensor in each group has the same unique metadata indices. In other words, in the example above, `in_train` and `out_train` will have the same unique "structure" metadata indices along the "samples" axes of each block. `in_test` and `out_test` will also have the same indices as eachother, but be distinct (zero intersection) with the indices in the train TensorMaps.

The function also returns a list of Labels object for the grouped indices (`grouped_idxs` in the ex. above). These show the `unique_metadata` for the specified `axis` and `names` present in each of the groups of split tensors.

<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--25.org.readthedocs.build/en/25/

<!-- readthedocs-preview equisolve end -->