### PR TITLE
update equistore version to include PR #128

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ packages = find:
 include_package_data = True
 
 install_requires =
-    equistore @ https://github.com/lab-cosmo/equistore/archive/467baf0.zip
+    equistore @ https://github.com/lab-cosmo/equistore/archive/ee3077.zip
     numpy
 
 [options.packages.find]


### PR DESCRIPTION
This is required to use the fixed mean_over_samples method in StandardScaler
<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--26.org.readthedocs.build/en/26/

<!-- readthedocs-preview equisolve end -->