### PR TITLE
Auto solver for Ridge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,4 +21,4 @@ For details, tutorials, and examples, please have a look at our `documentation`_
 
 .. |docs| image:: https://img.shields.io/badge/documentation-latest-sucess
    :alt: Documentation
-   :target: https://github.com/lab-cosmo/equisolve
+   :target: https://lab-cosmo.github.io/equisolve/latest/

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ include_package_data = True
 install_requires =
     equistore @ https://github.com/lab-cosmo/equistore/archive/ee3077b.zip
     numpy
+    scipy
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This PR gives an option for a solver and is adding the cholesky, cholesky_kernel (solving the dual problem) and auto solver. With the auto solver I tried to be as close as possable to scikit-learn.

What we do different to scikit-learn in the auto oslver:
- We choose the condition number different the current way as scipy.linalg.pinv does it. In skmatter it is commented that they do this, but it is different to the current way (https://github.com/scikit-learn/scikit-learn/blob/8c9c1f27b7e21201cfffb118934999025fd50cca/sklearn/linear_model/_ridge.py#L290 and compare with https://github.com/scipy/scipy/blob/c1ed5ece8ffbf05356a22a8106affcd11bd3aee0/scipy/linalg/_basic.py#L1341). Might be that scipy.linalg.pinv changed it.
- When the linalg.solve in primal space fails, scikit-learn uses svd. I am not sure how to apply here arbitrary alpha values, since the diagonal singular values correspond to the eigenvectors and not the original features. For now I use eigh on the noncentered convariance matrix (X.T @ X), and then apply the cutoff the eigvals, Cutting off the eigvals below a threshold should be that what makes the operation more stable, so it should be also more stable the way with eigh
_solve_svd from scikit-learn https://github.com/scikit-learn/scikit-learn/blob/8c9c1f27b7e21201cfffb118934999025fd50cca/sklearn/linear_model/_ridge.py#L294
- solver="cholesky" is different, scikit-learn does actually the same what we do in "auto" in their "cholesky". I thought from a user interface perspective, if the user specifies a solver (like "cholesky"), it is better that we do not switch around with solvers when they fail, but give also the error. I am okay if "auto" is a bit black-boxy, but not specified solver.

Additional comments:
- I reduces the test cases, because now with the solver it takes too long to run all tests

TODOs before merge:
- test_approx_ref_numpy_solver_regularization_2 fails for other solvers, I am not sure if this test makes sense or I have made a mistake

TODOs for next PR:
- add option to pass solver arguments in the fit function if not auto is chosen
- reduce test size, i 


<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--31.org.readthedocs.build/en/31/

<!-- readthedocs-preview equisolve end -->