### PR TITLE
Add wrappers for the selectors of skmatter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         include:
           - os: macos-11
             python-version: '3.10'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,5 @@ furo
 # When we update the equistore hash here we ALSO have to update the hash
 # in the rascaline branch!
 rascaline @ https://github.com/luthaf/rascaline/archive/equisolve.zip
-skmatter
 sphinx >=4.4
 sphinx-gallery

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,5 +8,6 @@ furo
 # When we update the equistore hash here we ALSO have to update the hash
 # in the rascaline branch!
 rascaline @ https://github.com/luthaf/rascaline/archive/equisolve.zip
+skmatter
 sphinx >=4.4
 sphinx-gallery

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -191,6 +191,7 @@ intersphinx_mapping = {
     "equistore": ("https://lab-cosmo.github.io/equistore/latest/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
+    "skmatter": ("https://scikit-matter.readthedocs.io/en/latest/", None),
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -30,6 +30,7 @@ version = equisolve.__version__
 extensions = [
     'sphinx.ext.autodoc', # import the modules you are documenting
     'sphinx.ext.intersphinx', # generate links to the documentation of objects in external projects
+    "sphinx.ext.viewcode", # add links to highlighted source code
     "sphinx_gallery.gen_gallery", # provides a source parser for *.ipynb files
 ]
 

--- a/docs/src/reference/index.rst
+++ b/docs/src/reference/index.rst
@@ -13,5 +13,6 @@ recipes how to stack the functions toegther you might take a look at the
     :maxdepth: 2
 
     preprocessing
+    selection/index.rst
     models
     utils/index

--- a/docs/src/reference/models.rst
+++ b/docs/src/reference/models.rst
@@ -1,6 +1,5 @@
-Regression Models
+Regression models
 =================
 
 .. automodule:: equisolve.numpy.models
     :members:
-    :show-inheritance:

--- a/docs/src/reference/preprocessing.rst
+++ b/docs/src/reference/preprocessing.rst
@@ -3,4 +3,3 @@ Preprocessing data
 
 .. automodule:: equisolve.numpy.preprocessing
     :members:
-    :show-inheritance:

--- a/docs/src/reference/selection/feature-selection.rst
+++ b/docs/src/reference/selection/feature-selection.rst
@@ -1,0 +1,6 @@
+Feature selection
+=================
+
+.. automodule:: equisolve.numpy.feature_selection
+    :members:
+    :show-inheritance:

--- a/docs/src/reference/selection/greedyselector.rst
+++ b/docs/src/reference/selection/greedyselector.rst
@@ -1,0 +1,5 @@
+``GreedySelector``
+==================
+
+.. autoclass:: equisolve.numpy._selection.GreedySelector
+    :members:

--- a/docs/src/reference/selection/index.rst
+++ b/docs/src/reference/selection/index.rst
@@ -1,0 +1,14 @@
+Feature and Sample Selection
+============================
+
+Wrappers for the selectors of `scikit-matter`_. The core of the wrapping is done
+by the :py:class:`equisolve.numpy._selection.GreedySelector` class.
+
+.. _`scikit-matter`: https://scikit-matter.readthedocs.io/en/latest/selection.html
+
+.. toctree::
+    :maxdepth: 1
+
+    greedyselector
+    feature-selection
+    sample-selection

--- a/docs/src/reference/selection/sample-selection.rst
+++ b/docs/src/reference/selection/sample-selection.rst
@@ -1,0 +1,6 @@
+Sample selection
+================
+
+.. automodule:: equisolve.numpy.sample_selection
+    :members:
+    :show-inheritance:

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ keywords =
     Science
     Machine Learning
 
-python_requires = >=3.7
+python_requires = >=3.8
 
 project_urls =
     Source = https://github.com/lab-cosmo/equisolve
@@ -48,6 +48,7 @@ install_requires =
     equistore @ https://github.com/lab-cosmo/equistore/archive/080e44a.zip
     numpy
     scipy
+    skmatter
 
 [options.packages.find]
 where = src

--- a/src/equisolve/numpy/__init__.py
+++ b/src/equisolve/numpy/__init__.py
@@ -6,7 +6,7 @@
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
 
-from . import models, utils
+from . import feature_selection, models, sample_selection, utils
 
 
-__all__ = ["models", "utils", "preprocessing"]
+__all__ = ["feature_selection", "models", "sample_selection", "utils"]

--- a/src/equisolve/numpy/_selection.py
+++ b/src/equisolve/numpy/_selection.py
@@ -5,28 +5,60 @@
 #
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
+from typing import List, Type
 
-from equistore import TensorMap, slice_block
-from skmatter._selection import GreedySelector
+import numpy as np
+import skmatter._selection
+from equistore import Labels, TensorBlock, TensorMap
+from equistore.operations import slice_block
+
+from .utils import dict_to_tensor_map, tensor_map_to_dict
 
 
 class GreedySelector:
-    """Wrapper for :py:class:`skmatter._selection.GreedySelector` for a
-    :py:class:equistore.TensorMap`.
+    """Wraps :py:class:`skmatter._selection.GreedySelector` for a TensorMap.
 
-    Create a selector for each block. The selection will be done based
-    the values of each :py:class:`TensorBlock`.
+    The class creates a selector for each block. The selection will be done based
+    the values of each :py:class:`TensorBlock`. Gradients will not be considered for
+    the selection.
     """
 
     def __init__(
-        self, selector: GreedySelector, selection_type: str, **selector_arguments
+        self,
+        selector_class: Type[skmatter._selection.GreedySelector],
+        selection_type: str,
+        **selector_arguments,
     ) -> None:
-        self.selection_type = selection_type
-        self.selector_arguments = selector_arguments
-        self.selector = selector
+        self._selector_class = selector_class
+        self._selection_type = selection_type
+        self._selector_arguments = selector_arguments
 
-        self.selector_arguments["selection_type"] = self.selection_type
-        self.selectors = {}
+        self._selector_arguments["selection_type"] = self._selection_type
+        self._support = None
+
+    @property
+    def selector_class(self) -> Type[skmatter._selection.GreedySelector]:
+        """The class to perform the selection."""
+        return self._selector_class
+
+    @property
+    def selection_type(self) -> str:
+        """Whether to choose a subset of columns ('feature') or rows ('sample')."""
+        return self._selection_type
+
+    @property
+    def selector_arguments(self) -> dict:
+        """Arguments passed to the ``selector_class``."""
+        return self._selector_arguments
+
+    @property
+    def support(self) -> TensorMap:
+        """TensorMap containing the support."""
+        if self._support is None:
+            raise ValueError("No selections. Call fit method first.")
+
+        #return dict_to_tensor_map(self._support)
+        return self._support
 
     def fit(self, X: TensorMap, warm_start: bool = False) -> None:
         """Learn the features to select.
@@ -40,9 +72,32 @@ class GreedySelector:
         if len(X.components_names) != 0:
             raise ValueError("Only blocks with no components are supported.")
 
-        for key, block in X:
-            selector = self.selector(**self.selector_arguments)
-            self.selectors[key] = selector.fit(block.values, warm_start=warm_start)
+        blocks = []
+        for _, block in X:
+            selector = self.selector_class(**self.selector_arguments)
+            selector.fit(block.values, warm_start=warm_start)
+            mask = selector.get_support()
+
+            if self._selection_type == "feature":
+                samples = Labels.single()
+                properties = block.properties[mask]
+                values = np.array([]).reshape(-1, len(properties))
+            elif self._selection_type == "sample":
+                samples = block.samples[mask]
+                properties = Labels.single()
+                values = np.array([]).reshape(len(samples), -1)
+
+            blocks.append(
+                TensorBlock(
+                    values=np.zeros([len(samples), len(properties)], dtype=np.int32),
+                    samples=samples,
+                    components=[],
+                    properties=properties,
+                )
+            )
+
+        #self._support = tensor_map_to_dict(TensorMap(X.keys, blocks))
+        self._support = TensorMap(X.keys, blocks)
 
         return self
 
@@ -54,22 +109,14 @@ class GreedySelector:
         :returns:
             The selected subset of the input.
         """
-        if len(self.selectors) == 0:
-            raise ValueError("No selections. Call fit method first.")
-
         blocks = []
         for key, block in X:
-            try:
-                selector = self.selectors[key]
-            except KeyError as err:
-                raise ValueError(f"Block with key {key} does not exist.") from err
+            block_support = self.support.block(key)
 
-            mask = selector.get_support()
-
-            if self.selection_type == "feature":
-                blocks.append(slice_block(block, properties=block.properties[mask]))
-            elif self.selection_type == "sample":
-                blocks.append(slice_block(block, samples=block.samples[mask]))
+            if self._selection_type == "feature":
+                blocks.append(slice_block(block, properties=block_support.properties))
+            elif self._selection_type == "sample":
+                blocks.append(slice_block(block, samples=block_support.samples))
 
         return TensorMap(X.keys, blocks)
 

--- a/src/equisolve/numpy/_selection.py
+++ b/src/equisolve/numpy/_selection.py
@@ -5,14 +5,12 @@
 #
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import List, Type
+from typing import Type
 
 import numpy as np
 import skmatter._selection
 from equistore import Labels, TensorBlock, TensorMap
 from equistore.operations import slice_block
-
-from .utils import dict_to_tensor_map, tensor_map_to_dict
 
 
 class GreedySelector:
@@ -57,7 +55,6 @@ class GreedySelector:
         if self._support is None:
             raise ValueError("No selections. Call fit method first.")
 
-        #return dict_to_tensor_map(self._support)
         return self._support
 
     def fit(self, X: TensorMap, warm_start: bool = False) -> None:
@@ -81,11 +78,9 @@ class GreedySelector:
             if self._selection_type == "feature":
                 samples = Labels.single()
                 properties = block.properties[mask]
-                values = np.array([]).reshape(-1, len(properties))
             elif self._selection_type == "sample":
                 samples = block.samples[mask]
                 properties = Labels.single()
-                values = np.array([]).reshape(len(samples), -1)
 
             blocks.append(
                 TensorBlock(
@@ -96,7 +91,6 @@ class GreedySelector:
                 )
             )
 
-        #self._support = tensor_map_to_dict(TensorMap(X.keys, blocks))
         self._support = TensorMap(X.keys, blocks)
 
         return self

--- a/src/equisolve/numpy/_selection.py
+++ b/src/equisolve/numpy/_selection.py
@@ -1,0 +1,85 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2023 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the BSD 3-Clause "New" or "Revised" License
+# SPDX-License-Identifier: BSD-3-Clause
+
+from equistore import TensorMap, slice_block
+from skmatter._selection import GreedySelector
+
+
+class GreedySelector:
+    """Wrapper for :py:class:`skmatter._selection.GreedySelector` for a
+    :py:class:equistore.TensorMap`.
+
+    Create a selector for each block. The selection will be done based
+    the values of each :py:class:`TensorBlock`.
+    """
+
+    def __init__(
+        self, selector: GreedySelector, selection_type: str, **selector_arguments
+    ) -> None:
+        self.selection_type = selection_type
+        self.selector_arguments = selector_arguments
+        self.selector = selector
+
+        self.selector_arguments["selection_type"] = self.selection_type
+        self.selectors = {}
+
+    def fit(self, X: TensorMap, warm_start: bool = False) -> None:
+        """Learn the features to select.
+
+        :param X:
+            Training vectors.
+        :param warm_start:
+            Whether the fit should continue after having already run, after increasing
+            `n_to_select`. Assumes it is called with the same X.
+        """
+        if len(X.components_names) != 0:
+            raise ValueError("Only blocks with no components are supported.")
+
+        for key, block in X:
+            selector = self.selector(**self.selector_arguments)
+            self.selectors[key] = selector.fit(block.values, warm_start=warm_start)
+
+        return self
+
+    def transform(self, X: TensorMap) -> TensorMap:
+        """Reduce X to the selected features.
+
+        :param X:
+            The input tensor.
+        :returns:
+            The selected subset of the input.
+        """
+        if len(self.selectors) == 0:
+            raise ValueError("No selections. Call fit method first.")
+
+        blocks = []
+        for key, block in X:
+            try:
+                selector = self.selectors[key]
+            except KeyError as err:
+                raise ValueError(f"Block with key {key} does not exist.") from err
+
+            mask = selector.get_support()
+
+            if self.selection_type == "feature":
+                blocks.append(slice_block(block, properties=block.properties[mask]))
+            elif self.selection_type == "sample":
+                blocks.append(slice_block(block, samples=block.samples[mask]))
+
+        return TensorMap(X.keys, blocks)
+
+    def fit_transform(self, X: TensorMap, warm_start: bool = False) -> TensorMap:
+        """Fit to data, then transform it.
+
+        :param X:
+            Training vectors.
+        :param warm_start:
+            Whether the fit should continue after having already run, after increasing
+            `n_to_select`. Assumes it is called with the same X.
+        """
+        return self.fit(X, warm_start=warm_start).transform(X)

--- a/src/equisolve/numpy/feature_selection.py
+++ b/src/equisolve/numpy/feature_selection.py
@@ -19,32 +19,7 @@ class FPS(GreedySelector):
     """
     Transformer that performs Greedy Feature Selection using Farthest Point Sampling.
 
-    :param initialize:
-        Index of the first selection(s). If 'random', picks a random
-        value when fit starts.
-    :param n_to_select:
-        The number of selections to make. If `None`, half of the features are
-        selected. If integer, the parameter is the absolute number of selections
-        to make. If float between 0 and 1, it is the fraction of the total dataset to
-        select.
-    :param score_threshold:
-        Threshold for the score. If `None` selection will continue until the
-        `n_to_select` is chosen. Otherwise will stop when the score falls below the
-        threshold.
-    :param score_threshold_type:
-        How to interpret the ``score_threshold``. When "absolute", the score used by the
-        selector is compared to the threshold directly. When "relative", at each
-        iteration, the score used by the selector is compared proportionally to the
-        score of the first selection, i.e. the selector quits when
-        ``current_score / first_score < threshold``.
-    :param progress_bar:
-        Pption to use `tqdm <https://tqdm.github.io/>`_ progress bar to monitor
-        selections.
-    :param full:
-        In the case that all non-redundant selections are exhausted, choose
-        randomly from the remaining features. Stored in :py:attr:`self.full`.
-    :param random_state:
-        The random state.
+    Refer to :py:class:`skmatter.feature_selection.FPS` for full documentation.
     """
 
     def __init__(
@@ -58,7 +33,7 @@ class FPS(GreedySelector):
         random_state=0,
     ):
         super().__init__(
-            selector=_FPS,
+            selector_class=_FPS,
             selection_type="feature",
             initialize=initialize,
             n_to_select=n_to_select,
@@ -73,39 +48,7 @@ class FPS(GreedySelector):
 class CUR(GreedySelector):
     """Transformer that performs Greedy Feature Selection with CUR.
 
-    The selector is choosing features which maximize the magnitude of the right singular
-    vectors, consistent with classic CUR matrix decomposition.
-
-    :param recompute_every:
-        Number of steps after which to recompute the pi score
-        defaults to 1, if 0 no re-computation is done
-    :param k:
-        Number of eigenvectors to compute the importance score with, defaults to 1
-    :param tolerance:
-        Threshold below which scores will be considered 0.
-    :param n_to_select:
-        The number of selections to make. If `None`, half of the samples are
-        selected. If integer, the parameter is the absolute number of selections
-        to make. If float between 0 and 1, it is the fraction of the total dataset to
-        select.
-    :param score_threshold:
-        Threshold for the score. If `None` selection will continue until the
-        `n_to_select` is chosen. Otherwise will stop when the score falls below the
-        threshold.
-    :param score_threshold_type:
-        How to interpret the ``score_threshold``. When "absolute", the score used by the
-        selector is compared to the threshold directly. When "relative", at each
-        iteration, the score used by the selector is compared proportionally to the
-        score of the first selection, i.e. the selector quits when
-        ``current_score / first_score < threshold``.
-    :param progress_bar:
-        option to use `tqdm <https://tqdm.github.io/>`_
-        progress bar to monitor selections.
-    :param full:
-        In the case that all non-redundant selections are exhausted, choose
-        randomly from the remaining samples. Stored in :py:attr:`self.full`.
-    :param random_state:
-        The random state.
+    Refer to :py:class:`skmatter.feature_selection.CUR` for full documentation.
     """
 
     def __init__(
@@ -121,7 +64,7 @@ class CUR(GreedySelector):
         random_state=0,
     ):
         super().__init__(
-            selector=_CUR,
+            selector_class=_CUR,
             selection_type="feature",
             recompute_every=recompute_every,
             k=k,

--- a/src/equisolve/numpy/feature_selection.py
+++ b/src/equisolve/numpy/feature_selection.py
@@ -1,0 +1,135 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2023 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the BSD 3-Clause "New" or "Revised" License
+# SPDX-License-Identifier: BSD-3-Clause
+"""Wrappers for the feature selectors of `scikit-matter`_.
+
+.. _`scikit-matter`: https://scikit-matter.readthedocs.io/en/latest/selection.html
+"""
+
+from skmatter._selection import _CUR, _FPS
+
+from ._selection import GreedySelector
+
+
+class FPS(GreedySelector):
+    """
+    Transformer that performs Greedy Feature Selection using Farthest Point Sampling.
+
+    :param initialize:
+        Index of the first selection(s). If 'random', picks a random
+        value when fit starts.
+    :param n_to_select:
+        The number of selections to make. If `None`, half of the features are
+        selected. If integer, the parameter is the absolute number of selections
+        to make. If float between 0 and 1, it is the fraction of the total dataset to
+        select.
+    :param score_threshold:
+        Threshold for the score. If `None` selection will continue until the
+        `n_to_select` is chosen. Otherwise will stop when the score falls below the
+        threshold.
+    :param score_threshold_type:
+        How to interpret the ``score_threshold``. When "absolute", the score used by the
+        selector is compared to the threshold directly. When "relative", at each
+        iteration, the score used by the selector is compared proportionally to the
+        score of the first selection, i.e. the selector quits when
+        ``current_score / first_score < threshold``.
+    :param progress_bar:
+        Pption to use `tqdm <https://tqdm.github.io/>`_ progress bar to monitor
+        selections.
+    :param full:
+        In the case that all non-redundant selections are exhausted, choose
+        randomly from the remaining features. Stored in :py:attr:`self.full`.
+    :param random_state:
+        The random state.
+    """
+
+    def __init__(
+        self,
+        initialize=0,
+        n_to_select=None,
+        score_threshold=None,
+        score_threshold_type="absolute",
+        progress_bar=False,
+        full=False,
+        random_state=0,
+    ):
+        super().__init__(
+            selector=_FPS,
+            selection_type="feature",
+            initialize=initialize,
+            n_to_select=n_to_select,
+            score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
+            progress_bar=progress_bar,
+            full=full,
+            random_state=random_state,
+        )
+
+
+class CUR(GreedySelector):
+    """Transformer that performs Greedy Feature Selection with CUR.
+
+    The selector is choosing features which maximize the magnitude of the right singular
+    vectors, consistent with classic CUR matrix decomposition.
+
+    :param recompute_every:
+        Number of steps after which to recompute the pi score
+        defaults to 1, if 0 no re-computation is done
+    :param k:
+        Number of eigenvectors to compute the importance score with, defaults to 1
+    :param tolerance:
+        Threshold below which scores will be considered 0.
+    :param n_to_select:
+        The number of selections to make. If `None`, half of the samples are
+        selected. If integer, the parameter is the absolute number of selections
+        to make. If float between 0 and 1, it is the fraction of the total dataset to
+        select.
+    :param score_threshold:
+        Threshold for the score. If `None` selection will continue until the
+        `n_to_select` is chosen. Otherwise will stop when the score falls below the
+        threshold.
+    :param score_threshold_type:
+        How to interpret the ``score_threshold``. When "absolute", the score used by the
+        selector is compared to the threshold directly. When "relative", at each
+        iteration, the score used by the selector is compared proportionally to the
+        score of the first selection, i.e. the selector quits when
+        ``current_score / first_score < threshold``.
+    :param progress_bar:
+        option to use `tqdm <https://tqdm.github.io/>`_
+        progress bar to monitor selections.
+    :param full:
+        In the case that all non-redundant selections are exhausted, choose
+        randomly from the remaining samples. Stored in :py:attr:`self.full`.
+    :param random_state:
+        The random state.
+    """
+
+    def __init__(
+        self,
+        recompute_every=1,
+        k=1,
+        tolerance=1e-12,
+        n_to_select=None,
+        score_threshold=None,
+        score_threshold_type="absolute",
+        progress_bar=False,
+        full=False,
+        random_state=0,
+    ):
+        super().__init__(
+            selector=_CUR,
+            selection_type="feature",
+            recompute_every=recompute_every,
+            k=k,
+            tolerance=tolerance,
+            n_to_select=n_to_select,
+            score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
+            progress_bar=progress_bar,
+            full=full,
+            random_state=random_state,
+        )

--- a/src/equisolve/numpy/sample_selection.py
+++ b/src/equisolve/numpy/sample_selection.py
@@ -19,32 +19,7 @@ class FPS(GreedySelector):
     """
     Transformer that performs Greedy Sample Selection using Farthest Point Sampling.
 
-    :param initialize:
-        Index of the first selection(s). If 'random', picks a random
-        value when fit starts.
-    :param n_to_select:
-        The number of selections to make. If `None`, half of the features are
-        selected. If integer, the parameter is the absolute number of selections
-        to make. If float between 0 and 1, it is the fraction of the total dataset to
-        select.
-    :param score_threshold:
-        Threshold for the score. If `None` selection will continue until the
-        `n_to_select` is chosen. Otherwise will stop when the score falls below the
-        threshold.
-    :param score_threshold_type:
-        How to interpret the ``score_threshold``. When "absolute", the score used by the
-        selector is compared to the threshold directly. When "relative", at each
-        iteration, the score used by the selector is compared proportionally to the
-        score of the first selection, i.e. the selector quits when
-        ``current_score / first_score < threshold``.
-    :param progress_bar:
-        Pption to use `tqdm <https://tqdm.github.io/>`_ progress bar to monitor
-        selections.
-    :param full:
-        In the case that all non-redundant selections are exhausted, choose
-        randomly from the remaining features. Stored in :py:attr:`self.full`.
-    :param random_state:
-        The random state.
+    Refer to :py:class:`skmatter.sample_selection.FPS` for full documentation.
     """
 
     def __init__(
@@ -58,7 +33,7 @@ class FPS(GreedySelector):
         random_state=0,
     ):
         super().__init__(
-            selector=_FPS,
+            selector_class=_FPS,
             selection_type="sample",
             initialize=initialize,
             n_to_select=n_to_select,
@@ -73,39 +48,7 @@ class FPS(GreedySelector):
 class CUR(GreedySelector):
     """Transformer that performs Greedy Sample Selection using CUR.
 
-    The selector is choosing samples which maximize the magnitude of the left
-    singular vectors, consistent with classic CUR matrix decomposition.
-
-    :param recompute_every:
-        Number of steps after which to recompute the pi score
-        defaults to 1, if 0 no re-computation is done
-    :param k:
-        Number of eigenvectors to compute the importance score with, defaults to 1
-    :param tolerance:
-        Threshold below which scores will be considered 0.
-    :param n_to_select:
-        The number of selections to make. If `None`, half of the samples are
-        selected. If integer, the parameter is the absolute number of selections
-        to make. If float between 0 and 1, it is the fraction of the total dataset to
-        select.
-    :param score_threshold:
-        Threshold for the score. If `None` selection will continue until the
-        `n_to_select` is chosen. Otherwise will stop when the score falls below the
-        threshold.
-    :param score_threshold_type:
-        How to interpret the ``score_threshold``. When "absolute", the score used by the
-        selector is compared to the threshold directly. When "relative", at each
-        iteration, the score used by the selector is compared proportionally to the
-        score of the first selection, i.e. the selector quits when
-        ``current_score / first_score < threshold``.
-    :param progress_bar:
-        option to use `tqdm <https://tqdm.github.io/>`_
-        progress bar to monitor selections.
-    :param full:
-        In the case that all non-redundant selections are exhausted, choose
-        randomly from the remaining samples. Stored in :py:attr:`self.full`.
-    :param random_state:
-        The random state.
+    Refer to :py:class:`skmatter.sample_selection.CUR` for full documentation.
     """
 
     def __init__(
@@ -121,7 +64,7 @@ class CUR(GreedySelector):
         random_state=0,
     ):
         super().__init__(
-            selector=_CUR,
+            selector_class=_CUR,
             selection_type="sample",
             recompute_every=recompute_every,
             k=k,

--- a/src/equisolve/numpy/sample_selection.py
+++ b/src/equisolve/numpy/sample_selection.py
@@ -1,0 +1,135 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2023 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the BSD 3-Clause "New" or "Revised" License
+# SPDX-License-Identifier: BSD-3-Clause
+"""Wrappers for the sample selectors of `scikit-matter`_.
+
+.. _`scikit-matter`: https://scikit-matter.readthedocs.io/en/latest/selection.html
+"""
+
+from skmatter._selection import _CUR, _FPS
+
+from ._selection import GreedySelector
+
+
+class FPS(GreedySelector):
+    """
+    Transformer that performs Greedy Sample Selection using Farthest Point Sampling.
+
+    :param initialize:
+        Index of the first selection(s). If 'random', picks a random
+        value when fit starts.
+    :param n_to_select:
+        The number of selections to make. If `None`, half of the features are
+        selected. If integer, the parameter is the absolute number of selections
+        to make. If float between 0 and 1, it is the fraction of the total dataset to
+        select.
+    :param score_threshold:
+        Threshold for the score. If `None` selection will continue until the
+        `n_to_select` is chosen. Otherwise will stop when the score falls below the
+        threshold.
+    :param score_threshold_type:
+        How to interpret the ``score_threshold``. When "absolute", the score used by the
+        selector is compared to the threshold directly. When "relative", at each
+        iteration, the score used by the selector is compared proportionally to the
+        score of the first selection, i.e. the selector quits when
+        ``current_score / first_score < threshold``.
+    :param progress_bar:
+        Pption to use `tqdm <https://tqdm.github.io/>`_ progress bar to monitor
+        selections.
+    :param full:
+        In the case that all non-redundant selections are exhausted, choose
+        randomly from the remaining features. Stored in :py:attr:`self.full`.
+    :param random_state:
+        The random state.
+    """
+
+    def __init__(
+        self,
+        initialize=0,
+        n_to_select=None,
+        score_threshold=None,
+        score_threshold_type="absolute",
+        progress_bar=False,
+        full=False,
+        random_state=0,
+    ):
+        super().__init__(
+            selector=_FPS,
+            selection_type="sample",
+            initialize=initialize,
+            n_to_select=n_to_select,
+            score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
+            progress_bar=progress_bar,
+            full=full,
+            random_state=random_state,
+        )
+
+
+class CUR(GreedySelector):
+    """Transformer that performs Greedy Sample Selection using CUR.
+
+    The selector is choosing samples which maximize the magnitude of the left
+    singular vectors, consistent with classic CUR matrix decomposition.
+
+    :param recompute_every:
+        Number of steps after which to recompute the pi score
+        defaults to 1, if 0 no re-computation is done
+    :param k:
+        Number of eigenvectors to compute the importance score with, defaults to 1
+    :param tolerance:
+        Threshold below which scores will be considered 0.
+    :param n_to_select:
+        The number of selections to make. If `None`, half of the samples are
+        selected. If integer, the parameter is the absolute number of selections
+        to make. If float between 0 and 1, it is the fraction of the total dataset to
+        select.
+    :param score_threshold:
+        Threshold for the score. If `None` selection will continue until the
+        `n_to_select` is chosen. Otherwise will stop when the score falls below the
+        threshold.
+    :param score_threshold_type:
+        How to interpret the ``score_threshold``. When "absolute", the score used by the
+        selector is compared to the threshold directly. When "relative", at each
+        iteration, the score used by the selector is compared proportionally to the
+        score of the first selection, i.e. the selector quits when
+        ``current_score / first_score < threshold``.
+    :param progress_bar:
+        option to use `tqdm <https://tqdm.github.io/>`_
+        progress bar to monitor selections.
+    :param full:
+        In the case that all non-redundant selections are exhausted, choose
+        randomly from the remaining samples. Stored in :py:attr:`self.full`.
+    :param random_state:
+        The random state.
+    """
+
+    def __init__(
+        self,
+        recompute_every=1,
+        k=1,
+        tolerance=1e-12,
+        n_to_select=None,
+        score_threshold=None,
+        score_threshold_type="absolute",
+        progress_bar=False,
+        full=False,
+        random_state=0,
+    ):
+        super().__init__(
+            selector=_CUR,
+            selection_type="sample",
+            recompute_every=recompute_every,
+            k=k,
+            tolerance=tolerance,
+            n_to_select=n_to_select,
+            score_threshold=score_threshold,
+            score_threshold_type=score_threshold_type,
+            progress_bar=progress_bar,
+            full=full,
+            random_state=random_state,
+        )

--- a/tests/equisolve_tests/numpy/test_feature_selection.py
+++ b/tests/equisolve_tests/numpy/test_feature_selection.py
@@ -1,0 +1,60 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2023 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the BSD 3-Clause "New" or "Revised" License
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import equistore
+import pytest
+import skmatter.feature_selection
+from numpy.testing import assert_equal
+
+from equisolve.numpy.feature_selection import CUR, FPS
+
+from .utils import random_single_block_no_components_tensor_map
+
+
+class TestSelection:
+    @pytest.fixture
+    def X(self):
+        return random_single_block_no_components_tensor_map()
+
+    @pytest.mark.parametrize(
+        "selector_cls, skmatter_cls",
+        [(FPS, skmatter.feature_selection.FPS), (CUR, skmatter.feature_selection.CUR)],
+    )
+    def test_fit(self, X, selector_cls, skmatter_cls):
+        selector = selector_cls(n_to_select=2)
+        selector.fit(X)
+        support = selector.selectors[X.keys[0]].get_support()
+
+        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector.fit(X[0].values)
+        skmatter_support = skmatter_selector.get_support()
+
+        assert_equal(support, skmatter_support)
+
+    @pytest.mark.parametrize(
+        "selector_cls, skmatter_cls",
+        [(FPS, skmatter.feature_selection.FPS), (CUR, skmatter.feature_selection.CUR)],
+    )
+    def test_transform(self, X, selector_cls, skmatter_cls):
+        selector = selector_cls(n_to_select=2)
+        selector.fit(X)
+        X_trans = selector.transform(X)
+
+        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector.fit(X[0].values)
+        X_trans_skmatter = skmatter_selector.transform(X[0].values)
+
+        assert_equal(X_trans[0].values, X_trans_skmatter)
+
+    @pytest.mark.parametrize("selector_cls", [FPS, CUR])
+    def test_fit_transform(self, X, selector_cls):
+        selector = selector_cls(n_to_select=2)
+
+        X_ft = selector.fit(X).transform(X)
+        equistore.equal_raise(selector.fit_transform(X), X_ft)

--- a/tests/equisolve_tests/numpy/test_feature_selection.py
+++ b/tests/equisolve_tests/numpy/test_feature_selection.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_equal
 
 from equisolve.numpy.feature_selection import CUR, FPS
 
-from .utils import random_single_block_no_components_tensor_map
+from .utilities import random_single_block_no_components_tensor_map
 
 
 class TestSelection:

--- a/tests/equisolve_tests/numpy/test_feature_selection.py
+++ b/tests/equisolve_tests/numpy/test_feature_selection.py
@@ -6,7 +6,7 @@
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
 
-
+import numpy as np
 import equistore
 import pytest
 import skmatter.feature_selection
@@ -23,38 +23,38 @@ class TestSelection:
         return random_single_block_no_components_tensor_map()
 
     @pytest.mark.parametrize(
-        "selector_cls, skmatter_cls",
+        "selector_class, skmatter_selector_class",
         [(FPS, skmatter.feature_selection.FPS), (CUR, skmatter.feature_selection.CUR)],
     )
-    def test_fit(self, X, selector_cls, skmatter_cls):
-        selector = selector_cls(n_to_select=2)
+    def test_fit(self, X, selector_class, skmatter_selector_class):
+        selector = selector_class(n_to_select=2)
         selector.fit(X)
-        support = selector.selectors[X.keys[0]].get_support()
+        support = selector.support[0].properties
 
-        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector = skmatter_selector_class(n_to_select=2)
         skmatter_selector.fit(X[0].values)
-        skmatter_support = skmatter_selector.get_support()
+        skmatter_support = skmatter_selector.get_support(indices=True)
 
-        assert_equal(support, skmatter_support)
+        assert_equal(np.flatten(support), skmatter_support)
 
     @pytest.mark.parametrize(
-        "selector_cls, skmatter_cls",
+        "selector_class, skmatter_selector_class",
         [(FPS, skmatter.feature_selection.FPS), (CUR, skmatter.feature_selection.CUR)],
     )
-    def test_transform(self, X, selector_cls, skmatter_cls):
-        selector = selector_cls(n_to_select=2)
+    def test_transform(self, X, selector_class, skmatter_selector_class):
+        selector = selector_class(n_to_select=2)
         selector.fit(X)
         X_trans = selector.transform(X)
 
-        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector = skmatter_selector_class(n_to_select=2)
         skmatter_selector.fit(X[0].values)
         X_trans_skmatter = skmatter_selector.transform(X[0].values)
 
         assert_equal(X_trans[0].values, X_trans_skmatter)
 
-    @pytest.mark.parametrize("selector_cls", [FPS, CUR])
-    def test_fit_transform(self, X, selector_cls):
-        selector = selector_cls(n_to_select=2)
+    @pytest.mark.parametrize("selector_class", [FPS, CUR])
+    def test_fit_transform(self, X, selector_class):
+        selector = selector_class(n_to_select=2)
 
         X_ft = selector.fit(X).transform(X)
         equistore.equal_raise(selector.fit_transform(X), X_ft)

--- a/tests/equisolve_tests/numpy/test_feature_selection.py
+++ b/tests/equisolve_tests/numpy/test_feature_selection.py
@@ -5,8 +5,6 @@
 #
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
-
-import numpy as np
 import equistore
 import pytest
 import skmatter.feature_selection
@@ -29,13 +27,13 @@ class TestSelection:
     def test_fit(self, X, selector_class, skmatter_selector_class):
         selector = selector_class(n_to_select=2)
         selector.fit(X)
-        support = selector.support[0].properties
+        support = selector.support[0].properties["properties"]
 
         skmatter_selector = skmatter_selector_class(n_to_select=2)
         skmatter_selector.fit(X[0].values)
         skmatter_support = skmatter_selector.get_support(indices=True)
 
-        assert_equal(np.flatten(support), skmatter_support)
+        assert_equal(support, skmatter_support)
 
     @pytest.mark.parametrize(
         "selector_class, skmatter_selector_class",

--- a/tests/equisolve_tests/numpy/test_sample_selection.py
+++ b/tests/equisolve_tests/numpy/test_sample_selection.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_equal
 
 from equisolve.numpy.sample_selection import CUR, FPS
 
-from .utils import random_single_block_no_components_tensor_map
+from .utilities import random_single_block_no_components_tensor_map
 
 
 class TestSelection:

--- a/tests/equisolve_tests/numpy/test_sample_selection.py
+++ b/tests/equisolve_tests/numpy/test_sample_selection.py
@@ -23,38 +23,38 @@ class TestSelection:
         return random_single_block_no_components_tensor_map()
 
     @pytest.mark.parametrize(
-        "selector_cls, skmatter_cls",
+        "selector_class, skmatter_selector_class",
         [(FPS, skmatter.sample_selection.FPS), (CUR, skmatter.sample_selection.CUR)],
     )
-    def test_fit(self, X, selector_cls, skmatter_cls):
-        selector = selector_cls(n_to_select=2)
+    def test_fit(self, X, selector_class, skmatter_selector_class):
+        selector = selector_class(n_to_select=2)
         selector.fit(X)
         support = selector.selectors[X.keys[0]].get_support()
 
-        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector = skmatter_selector_class(n_to_select=2)
         skmatter_selector.fit(X[0].values)
         skmatter_support = skmatter_selector.get_support()
 
         assert_equal(support, skmatter_support)
 
     @pytest.mark.parametrize(
-        "selector_cls, skmatter_cls",
+        "selector_class, skmatter_selector_class",
         [(FPS, skmatter.sample_selection.FPS), (CUR, skmatter.sample_selection.CUR)],
     )
-    def test_transform(self, X, selector_cls, skmatter_cls):
-        selector = selector_cls(n_to_select=2)
+    def test_transform(self, X, selector_class, skmatter_selector_class):
+        selector = selector_class(n_to_select=2)
         selector.fit(X)
         X_trans = selector.transform(X)
 
-        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector = skmatter_selector_class(n_to_select=2)
         skmatter_selector.fit(X[0].values)
         X_trans_skmatter = skmatter_selector.transform(X[0].values)
 
         assert_equal(X_trans[0].values, X_trans_skmatter)
 
-    @pytest.mark.parametrize("selector_cls", [FPS, CUR])
-    def test_fit_transform(self, X, selector_cls):
-        selector = selector_cls(n_to_select=2)
+    @pytest.mark.parametrize("selector_class", [FPS, CUR])
+    def test_fit_transform(self, X, selector_class):
+        selector = selector_class(n_to_select=2)
 
         X_ft = selector.fit(X).transform(X)
         equistore.equal_raise(selector.fit_transform(X), X_ft)

--- a/tests/equisolve_tests/numpy/test_sample_selection.py
+++ b/tests/equisolve_tests/numpy/test_sample_selection.py
@@ -1,0 +1,60 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2023 Authors and contributors
+# (see the AUTHORS.rst file for the full list of names)
+#
+# Released under the BSD 3-Clause "New" or "Revised" License
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import equistore
+import pytest
+import skmatter.sample_selection
+from numpy.testing import assert_equal
+
+from equisolve.numpy.sample_selection import CUR, FPS
+
+from .utils import random_single_block_no_components_tensor_map
+
+
+class TestSelection:
+    @pytest.fixture
+    def X(self):
+        return random_single_block_no_components_tensor_map()
+
+    @pytest.mark.parametrize(
+        "selector_cls, skmatter_cls",
+        [(FPS, skmatter.sample_selection.FPS), (CUR, skmatter.sample_selection.CUR)],
+    )
+    def test_fit(self, X, selector_cls, skmatter_cls):
+        selector = selector_cls(n_to_select=2)
+        selector.fit(X)
+        support = selector.selectors[X.keys[0]].get_support()
+
+        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector.fit(X[0].values)
+        skmatter_support = skmatter_selector.get_support()
+
+        assert_equal(support, skmatter_support)
+
+    @pytest.mark.parametrize(
+        "selector_cls, skmatter_cls",
+        [(FPS, skmatter.sample_selection.FPS), (CUR, skmatter.sample_selection.CUR)],
+    )
+    def test_transform(self, X, selector_cls, skmatter_cls):
+        selector = selector_cls(n_to_select=2)
+        selector.fit(X)
+        X_trans = selector.transform(X)
+
+        skmatter_selector = skmatter_cls(n_to_select=2)
+        skmatter_selector.fit(X[0].values)
+        X_trans_skmatter = skmatter_selector.transform(X[0].values)
+
+        assert_equal(X_trans[0].values, X_trans_skmatter)
+
+    @pytest.mark.parametrize("selector_cls", [FPS, CUR])
+    def test_fit_transform(self, X, selector_cls):
+        selector = selector_cls(n_to_select=2)
+
+        X_ft = selector.fit(X).transform(X)
+        equistore.equal_raise(selector.fit_transform(X), X_ft)

--- a/tests/equisolve_tests/numpy/test_sample_selection.py
+++ b/tests/equisolve_tests/numpy/test_sample_selection.py
@@ -5,8 +5,6 @@
 #
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
-
-
 import equistore
 import pytest
 import skmatter.sample_selection
@@ -29,11 +27,11 @@ class TestSelection:
     def test_fit(self, X, selector_class, skmatter_selector_class):
         selector = selector_class(n_to_select=2)
         selector.fit(X)
-        support = selector.selectors[X.keys[0]].get_support()
+        support = selector.support[0].samples["structure"]
 
         skmatter_selector = skmatter_selector_class(n_to_select=2)
         skmatter_selector.fit(X[0].values)
-        skmatter_support = skmatter_selector.get_support()
+        skmatter_support = skmatter_selector.get_support(indices=True)
 
         assert_equal(support, skmatter_support)
 


### PR DESCRIPTION
TensorMap versions for FPS and CUR sample and feature selection. The current implementation works only for a `TensorMap` without components.

# TODO
 - [x] Tests

<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--39.org.readthedocs.build/en/39/

<!-- readthedocs-preview equisolve end -->