### PR TITLE
Remove `parameter_key` option

### DIFF
--- a/examples/linear-model.py
+++ b/examples/linear-model.py
@@ -127,13 +127,9 @@ print(y[0])
 # -------------------
 #
 # We first initilize the :class:`equisolve.numpy.models.linear_model.Ridge`
-# object. A mandatory parameter are the ``parameter_keys`` determining with
-# respect to which parameters the regression or fit is
-# performed. Here, we choose a regression wrt. to ``"values"`` (energies) and
-# ``"positions"`` (forces).
+# object. We automically learn on forces if forces are present.
 
-
-clf = Ridge(parameter_keys=["values", "positions"])
+clf = Ridge()
 
 # %%
 #

--- a/src/equisolve/numpy/models/linear_model.py
+++ b/src/equisolve/numpy/models/linear_model.py
@@ -6,7 +6,7 @@
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import equistore
 import numpy as np
@@ -16,7 +16,7 @@ from equistore import Labels, TensorBlock, TensorMap
 from ... import HAS_TORCH
 from ...module import NumpyModule, _Estimator
 from ...utils.metrics import rmse
-from ..utils import block_to_array, dict_to_tensor_map, tensor_map_to_dict
+from ..utils import array_from_block, dict_to_tensor_map, tensor_map_to_dict
 
 
 class _Ridge(_Estimator):
@@ -34,21 +34,9 @@ class _Ridge(_Estimator):
     Ridge will regress a model for each block in X. If a block contains components
     the component values will be stacked along the sample dimension for the fit.
     Therefore, the corresponding weights will be the same for each component.
-
-    :param parameter_keys:
-        Parameters to perform the regression for. Examples are ``"values"``,
-        ``"positions"``, ``"cell"`` or a combination of these.
     """
 
-    def __init__(
-        self,
-        parameter_keys: Union[List[str], str] = None,
-    ) -> None:
-        if type(parameter_keys) not in (list, tuple, np.ndarray):
-            self.parameter_keys = [parameter_keys]
-        else:
-            self.parameter_keys = parameter_keys
-
+    def __init__(self) -> None:
         self._weights = None
 
     def _validate_data(self, X: TensorMap, y: Optional[TensorMap] = None) -> None:
@@ -126,16 +114,16 @@ class _Ridge(_Estimator):
         # Convert TensorMaps into arrays for processing them with NumPy.
 
         # X_arr has shape of (n_targets, n_properties)
-        X_arr = block_to_array(X, self.parameter_keys)
+        X_arr = array_from_block(X)
 
         # y_arr has shape lentgth of n_targets
-        y_arr = block_to_array(y, self.parameter_keys)
+        y_arr = array_from_block(y)
 
         # sw_arr has shape of (n_samples, 1)
-        sw_arr = block_to_array(sample_weight, self.parameter_keys)
+        sw_arr = array_from_block(sample_weight)
 
         # alpha_arr has shape of (1, n_properties)
-        alpha_arr = block_to_array(alpha, ["values"])
+        alpha_arr = array_from_block(alpha)
 
         # Flatten into 1d arrays
         y_arr = y_arr.ravel()
@@ -241,6 +229,10 @@ class _Ridge(_Estimator):
     ) -> None:
         """Fit a regression model to each block in `X`.
 
+        Ridge takes all available values and gradients in the provided TensorMap for the
+        fit. Gradients can be exlcuded from the fit if removed from the TensorMap.
+        See :py:func:`equistore.remove_gradients` for details.
+
         :param X:
             training data
         :param y:
@@ -298,6 +290,9 @@ class _Ridge(_Estimator):
 
         self._validate_data(X, y)
         self._validate_params(X, alpha, sample_weight)
+
+        # Remove all gradients here. This is a workaround for now....
+        alpha = equistore.remove_gradients(alpha)
 
         weights_blocks = []
         for key, X_block in X:
@@ -357,24 +352,18 @@ class _Ridge(_Estimator):
 
 
 class NumpyRidge(_Ridge, NumpyModule):
-    def __init__(
-        self,
-        parameter_keys: Union[List[str], str] = None,
-    ) -> None:
+    def __init__(self) -> None:
         NumpyModule.__init__(self)
-        _Ridge.__init__(self, parameter_keys)
+        _Ridge.__init__(self)
 
 
 if HAS_TORCH:
     import torch
 
     class TorchRidge(_Ridge, torch.nn.Module):
-        def __init__(
-            self,
-            parameter_keys: Union[List[str], str] = None,
-        ) -> None:
+        def __init__(self) -> None:
             torch.nn.Module.__init__(self)
-            _Ridge.__init__(self, parameter_keys)
+            _Ridge.__init__(self)
 
     Ridge = TorchRidge
 else:

--- a/src/equisolve/numpy/models/linear_model.py
+++ b/src/equisolve/numpy/models/linear_model.py
@@ -291,7 +291,8 @@ class _Ridge(_Estimator):
         self._validate_data(X, y)
         self._validate_params(X, alpha, sample_weight)
 
-        # Remove all gradients here. This is a workaround for now....
+        # Remove all gradients here. This is a workaround until we can exclude gradients
+        # for metadata check (see equistore issue #285 for details)
         alpha = equistore.remove_gradients(alpha)
 
         weights_blocks = []

--- a/src/equisolve/numpy/utils.py
+++ b/src/equisolve/numpy/utils.py
@@ -8,14 +8,13 @@
 
 import os
 import tempfile
-from typing import List
 
 import equistore
 import numpy as np
-from equistore import Labels, TensorBlock, TensorMap
+from equistore import TensorBlock, TensorMap
 
 
-def block_to_array(block: TensorBlock, parameter_keys: List[str]) -> np.ndarray:
+def array_from_block(block: TensorBlock) -> np.ndarray:
     """Extract parts of a :class:`equistore.TensorBlock` into a array.
 
     All components will be stacked along the rows / "sample"-dimension.
@@ -23,8 +22,6 @@ def block_to_array(block: TensorBlock, parameter_keys: List[str]) -> np.ndarray:
 
     :param block:
         :class:`equistore.TensorBlock` for the extraction
-    :param value_keys:
-        List of keys specifying the parameter of the block which will be extracted.
     :returns M:
         :class:`numpy.ndarray` of shape (n, m) where m is the number of properties in
         the block.
@@ -35,90 +32,13 @@ def block_to_array(block: TensorBlock, parameter_keys: List[str]) -> np.ndarray:
     work for Kernel models.
     """
     M = []
-    for parameter in parameter_keys:
+    for parameter in ["values"] + block.gradients_list():
         if parameter == "values":
-            data = block.values
+            values = block.values
         else:
-            data = block.gradient(parameter).values
-        M.append(data.reshape(np.prod(data.shape[:-1]), data.shape[-1]))
+            values = block.gradient(parameter).values
+        M.append(values.reshape(np.prod(values.shape[:-1]), values.shape[-1]))
     return np.vstack(M)
-
-
-def matrix_to_block(
-    a: np.ndarray, sample_name: str = "sample", property_name: str = "property"
-) -> TensorBlock:
-    """Create a :class:`equistore.TensorBlock` from 2d :class`numpy.ndarray`.
-
-    The values of the block are the same as `a`. The name of the property labels
-    is `'property' and name of the sample labels are `'sample'`. The block has
-    no components.
-
-    :param a:
-        2d numpy array for Blocks values
-    :param sample_name:
-        name of the TensorBlocks' samples
-    :param property_name:
-        name of the TensorMaps' properties
-
-    :returns block:
-        block with filled values
-
-    Example:
-    >>> a = np.zeros([2,2])
-    >>> block = matrix_to_block(a)
-    >>> print(block)
-    """
-
-    if len(a.shape) != 2:
-        raise ValueError(f"`a` has {len(a.shape)} but must have exactly 2")
-
-    n_samples, n_properties = a.shape
-
-    samples = Labels([sample_name], np.arange(n_samples).reshape(-1, 1))
-    properties = Labels([property_name], np.arange(n_properties).reshape(-1, 1))
-
-    block = TensorBlock(
-        values=a,
-        samples=samples,
-        components=[],
-        properties=properties,
-    )
-
-    return block
-
-
-def tensor_to_tensormap(a: np.ndarray, key_name: str = "keys") -> TensorMap:
-    """Create a :class:`equistore.TensorMap` from 3d :class`numpy.ndarray`.
-
-    First dimension of a defines the number of blocks.
-    The values of each block are taken from the second and the third dimension.
-    The name of the property labels in each block is `'property' and name of the sample
-    labels is `'sample'`. The blocks have no components.
-
-    :param a:
-        3d numpy array for the block of the TensorMap values
-    :param key_name:
-        name of the TensorMaps' keys
-
-    :returns:
-        TensorMap with filled values
-
-
-    Example:
-    >>> a = np.zeros([2,2])
-    >>> # make 2d array 3d tensor
-    >>> tensor = tensor_to_tensormap(a[np.newaxis, :])
-    >>> print(tensor)
-    """
-    if len(a.shape) != 3:
-        raise ValueError(f"`a` has {len(a.shape)} but must have exactly 3")
-
-    blocks = []
-    for values in a:
-        blocks.append(matrix_to_block(values))
-
-    keys = Labels([key_name], np.arange(len(blocks)).reshape(-1, 1))
-    return TensorMap(keys, blocks)
 
 
 def tensor_map_to_dict(tensor_map: TensorMap):

--- a/src/equisolve/numpy/utils.py
+++ b/src/equisolve/numpy/utils.py
@@ -31,13 +31,10 @@ def array_from_block(block: TensorBlock) -> np.ndarray:
     This function is used for creating the X and the y for Linear models. It may not
     work for Kernel models.
     """
-    M = []
-    for parameter in ["values"] + block.gradients_list():
-        if parameter == "values":
-            values = block.values
-        else:
-            values = block.gradient(parameter).values
-        M.append(values.reshape(np.prod(values.shape[:-1]), values.shape[-1]))
+    M = [block.values.reshape(-1, block.values.shape[-1])]
+    for parameter in block.gradients_list():
+        values = block.gradient(parameter).values
+        M.append(values.reshape(-1, values.shape[-1]))
     return np.vstack(M)
 
 

--- a/tests/equisolve_tests/numpy/preprocessing/base.py
+++ b/tests/equisolve_tests/numpy/preprocessing/base.py
@@ -29,9 +29,7 @@ class TestStandardScaler:
     @pytest.mark.parametrize("with_mean", [True, False])
     @pytest.mark.parametrize("with_std", [True, False])
     def test_standard_scaler_transform(self, with_mean, with_std):
-        parameter_keys = ["values", "positions"]
         st = StandardScaler(
-            parameter_keys=parameter_keys,
             with_mean=with_mean,
             with_std=with_std,
             column_wise=False,
@@ -54,8 +52,7 @@ class TestStandardScaler:
                 rtol=self.relative_tolerance,
             )
 
-        parameter_keys.remove("values")
-        for parameter in parameter_keys:
+        for parameter in X_t[0].gradients_list():
             X_grad = X_t[0].gradient(parameter)
             X_grad = X_grad.values.reshape(-1, X_grad.values.shape[-1])
             if with_mean:
@@ -71,9 +68,7 @@ class TestStandardScaler:
     @pytest.mark.parametrize("with_mean", [True, False])
     @pytest.mark.parametrize("with_std", [True, False])
     def test_standard_scaler_inverse_transform(self, with_mean, with_std):
-        parameter_keys = ["values", "positions"]
         st = StandardScaler(
-            parameter_keys=parameter_keys,
             with_mean=with_mean,
             with_std=with_std,
             column_wise=False,
@@ -87,8 +82,7 @@ class TestStandardScaler:
             rtol=self.relative_tolerance,
         )
 
-        parameter_keys.remove("values")
-        for parameter in parameter_keys:
+        for parameter in self.X[0].gradients_list():
             X_grad = self.X[0].gradient(parameter)
             assert_allclose(
                 X_grad.values,

--- a/tests/equisolve_tests/numpy/utilities.py
+++ b/tests/equisolve_tests/numpy/utilities.py
@@ -1,3 +1,4 @@
+import equistore
 import numpy as np
 from equistore import Labels, TensorBlock, TensorMap
 
@@ -55,3 +56,37 @@ def random_single_block_no_components_tensor_map():
     block_1.add_gradient("cell", cell_gradient)
 
     return TensorMap(Labels.single(), [block_1])
+
+
+def tensor_to_tensormap(a: np.ndarray, key_name: str = "keys") -> TensorMap:
+    """Create a :class:`equistore.TensorMap` from 3d :class`numpy.ndarray`.
+
+    First dimension of a defines the number of blocks.
+    The values of each block are taken from the second and the third dimension.
+    The name of the property labels in each block is `'property' and name of the sample
+    labels is `'sample'`. The blocks have no components.
+
+    :param a:
+        3d numpy array for the block of the TensorMap values
+    :param key_name:
+        name of the TensorMaps' keys
+
+    :returns:
+        TensorMap with filled values
+
+
+    Example:
+    >>> a = np.zeros([2,2])
+    >>> # make 2d array 3d tensor
+    >>> tensor = tensor_to_tensormap(a[np.newaxis, :])
+    >>> print(tensor)
+    """
+    if len(a.shape) != 3:
+        raise ValueError(f"`a` has {len(a.shape)} but must have exactly 3")
+
+    blocks = []
+    for values in a:
+        blocks.append(equistore.block_from_array(values))
+
+    keys = Labels([key_name], np.arange(len(blocks)).reshape(-1, 1))
+    return TensorMap(keys, blocks)

--- a/tests/equisolve_tests/numpy/utilities.py
+++ b/tests/equisolve_tests/numpy/utilities.py
@@ -88,5 +88,5 @@ def tensor_to_tensormap(a: np.ndarray, key_name: str = "keys") -> TensorMap:
     for values in a:
         blocks.append(equistore.block_from_array(values))
 
-    keys = Labels([key_name], np.arange(len(blocks)).reshape(-1, 1))
+    keys = Labels.arange(key_name, len(blocks))
     return TensorMap(keys, blocks)

--- a/tests/equisolve_tests/numpy/utils.py
+++ b/tests/equisolve_tests/numpy/utils.py
@@ -10,10 +10,10 @@ import pytest
 from equistore import Labels, TensorBlock
 from numpy.testing import assert_equal
 
-from equisolve.numpy.utils import block_to_array
+from equisolve.numpy.utils import array_from_block
 
 
-class Testblock_to_array:
+class Testarray_from_block:
     """Test the conversion of a TensorBlock into a numpy array."""
 
     n_samples = 3
@@ -32,32 +32,35 @@ class Testblock_to_array:
         )
 
     @pytest.fixture
-    def block(self, values, gradient_values):
+    def block(self, values):
         properties = Labels(["property"], np.arange(self.n_properties).reshape(-1, 1))
         samples = Labels(["sample"], np.arange(self.n_samples).reshape(-1, 1))
 
         block = TensorBlock(
             values=values, samples=samples, components=[], properties=properties
         )
+        return block
 
+    @pytest.fixture
+    def block_gradient(self, block, gradient_values):
         gradient = TensorBlock(
             values=gradient_values,
-            samples=samples,
+            samples=block.samples,
             components=[Labels(["direction"], np.arange(3).reshape(-1, 1))],
             properties=block.properties,
         )
-        block.add_gradient("positions", gradient)
 
+        block.add_gradient("positions", gradient)
         return block
 
     def test_values(self, block, values):
         """Test extraction of values"""
-        block_mat = block_to_array(block, parameter_keys=["values"])
+        block_mat = array_from_block(block)
 
         assert_equal(block_mat, values)
 
-    def test_values_gradients(self, block, values, gradient_values):
-        block_mat = block_to_array(block, parameter_keys=["values", "positions"])
+    def test_values_gradients(self, block_gradient, values, gradient_values):
+        block_mat = array_from_block(block_gradient)
 
         assert_equal(
             block_mat,
@@ -81,7 +84,7 @@ class Testblock_to_array:
             properties=properties,
         )
 
-        block_mat = block_to_array(block, parameter_keys=["values"])
+        block_mat = array_from_block(block)
 
         assert_equal(
             block_mat,

--- a/tests/equisolve_tests/utils/metrics.py
+++ b/tests/equisolve_tests/utils/metrics.py
@@ -5,11 +5,11 @@
 #
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
+import equistore
 import numpy as np
 from equistore import Labels, TensorBlock, TensorMap
 from numpy.testing import assert_allclose, assert_equal
 
-from equisolve.numpy.utils import matrix_to_block, tensor_to_tensormap
 from equisolve.utils import rmse
 
 
@@ -19,8 +19,14 @@ class Testrmse:
         y_true_data = np.array([[0.5, 1], [-1, 1], [7, -6]])[:, :, np.newaxis]
         y_pred_data = np.array([[0, 2], [-1, 2], [8, -5]])[:, :, np.newaxis]
 
-        y_true = tensor_to_tensormap(y_true_data)
-        y_pred = tensor_to_tensormap(y_pred_data)
+        y_true = TensorMap(
+            Labels.arange("key", 3),
+            [equistore.block_from_array(y) for y in y_true_data],
+        )
+        y_pred = TensorMap(
+            Labels.arange("key", 3),
+            [equistore.block_from_array(y) for y in y_pred_data],
+        )
 
         assert_allclose(
             rmse(y_true, y_pred, parameter_key="values"),
@@ -40,7 +46,7 @@ class Testrmse:
 
         # Create training data
         X_values = X_arr[:num_targets]
-        X_block = matrix_to_block(X_values)
+        X_block = equistore.block_from_array(X_values)
 
         X_gradient_values = X_arr[num_targets:].reshape(num_targets, 3, num_properties)
 


### PR DESCRIPTION
The `parameter_key` might be confusing and makes the classes more complicated. As discussed with @Luthaf and @agoscinski we should remove this option and take all available data (values, gradients) in a TensorMap for creating a model.

This PR removes the option and also adds a hint in the docs what to do if one does not want to consider gradients.

Also uses the block_from_array function from equistore instead of the function we had here.

<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--49.org.readthedocs.build/en/49/

<!-- readthedocs-preview equisolve end -->