### PR TITLE
Use pre-build builds for metatensor

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     - cmake
   tools:
     python: "3.10"
-    rust: "1.64"
+    rust: "1.70"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,6 @@
 ase
 matplotlib
 furo
-# Since the metatensor version hash in rascaline might be two old for equisolve,
-# we load a specific branch that has the same metatensor hash as we are using
-# here.
-#
-# When we update the metatensor hash here we ALSO have to update the hash
-# in the rascaline branch!
-rascaline @ https://github.com/luthaf/rascaline/archive/23448bd.zip
+rascaline @ https://github.com/luthaf/rascaline/archive/581d0ca.zip
 sphinx >=4.4
 sphinx-gallery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ keywords = [
 requires-python = ">=3.7"
 
 dependencies = [
-    "metatensor @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip",
+    "metatensor",
     "numpy",
     "scipy",
     "skmatter"
 ]
 [project.optional-dependencies]
-torch = ["metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip"]
+torch = ["metatensor[torch]"]
 
 [project.urls]
 homepage = "https://lab-cosmo.github.io/equisolve/latest/"

--- a/src/equisolve/numpy/_selection.py
+++ b/src/equisolve/numpy/_selection.py
@@ -85,12 +85,12 @@ class GreedySelector:
             increasing `n_to_select`. Assumes it is called with the same X.
         """
         # Check that we have only 0 or 1 comoponent axes
-        if len(X.components_names) == 0:
+        if len(X.component_names) == 0:
             has_components = False
-        elif len(X.components_names) == 1:
+        elif len(X.component_names) == 1:
             has_components = True
         else:
-            assert len(X.components_names) > 1
+            assert len(X.component_names) > 1
             raise ValueError("Can only handle TensorMaps with a single component axis.")
 
         support_blocks = []

--- a/src/equisolve/numpy/models/linear_model.py
+++ b/src/equisolve/numpy/models/linear_model.py
@@ -272,8 +272,8 @@ class _Ridge(_Estimator):
             # Create a TensorMap with a single sample and the same components and
             # properties as X
             samples = Labels(
-                names=X.samples_names,
-                values=np.zeros([1, len(X.samples_names)], dtype=int),
+                names=X.sample_names,
+                values=np.zeros([1, len(X.sample_names)], dtype=int),
             )
             new_blocks = []
             for X_block in X.blocks():

--- a/src/equisolve/numpy/preprocessing/_base.py
+++ b/src/equisolve/numpy/preprocessing/_base.py
@@ -51,7 +51,7 @@ class _StandardScaler(_Transformer):
         :param X: training data to check
         :param y: target data to check
         """
-        if len(X.components_names) != 0:
+        if len(X.component_names) != 0:
             raise ValueError("X contains components")
 
         if y is not None:
@@ -60,7 +60,7 @@ class _StandardScaler(_Transformer):
                     "Metadata (samples) of X and sample_weight does not agree!"
                 )
 
-            if len(y.components_names) != 0:
+            if len(y.component_names) != 0:
                 raise ValueError("y contains components")
 
     def fit(

--- a/src/equisolve/utils/split_data.py
+++ b/src/equisolve/utils/split_data.py
@@ -389,9 +389,7 @@ def _check_args(
     if not all([isinstance(name, str) for name in names]):
         raise TypeError(f"`names` must be a list of str, got {type(names)}")
     for tensor in tensors:
-        tmp_names = (
-            tensor.samples_names if axis == "samples" else tensor.properties_names
-        )
+        tmp_names = tensor.sample_names if axis == "samples" else tensor.property_names
         for name in names:
             if name not in tmp_names:
                 raise ValueError(

--- a/tests/equisolve_tests/numpy/models/linear_model.py
+++ b/tests/equisolve_tests/numpy/models/linear_model.py
@@ -485,7 +485,7 @@ class TestRidge:
 
         # Slice TensorMaps to do not start at sample 0.
         # Testing probable hardcoded sample
-        samples = Labels(names=X.samples_names, values=X[0].samples.values[1:])
+        samples = Labels(names=X.sample_names, values=X[0].samples.values[1:])
         kwargs = {"axis": "samples", "labels": samples}
         X = metatensor.slice(X, **kwargs)
         y = metatensor.slice(y, **kwargs)
@@ -604,7 +604,7 @@ class TestRidge:
         clf = Ridge()
         clf.fit(X=X, y=y)
 
-        assert clf.weights.components_names == ["property"]
+        assert clf.weights.component_names == ["property"]
         assert clf.weights[0].values.shape == (1, 1, 1)
 
     @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,13 @@ envlist =
 lint_folders = {toxinidir}/examples {toxinidir}/src {toxinidir}/tests
 
 [testenv]
+# we use by default the cpu version of torch, if the cuda version is desired
+# please overwrite the PIP_EXTRA_INDEX_URL
+setenv =
+    PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 
 [testenv:core-numpy-tests]
-# this environement runs Python tests with core
+description = Runs Python tests with core
 usedevelop = true
 deps =
     ase
@@ -22,7 +26,7 @@ commands =
     pytest --import-mode=append {posargs}
 
 [testenv:core-torch-tests]
-# this environement runs Python tests only with metatensor-core
+description = Runs Python tests only with metatensor-core
 usedevelop = {[testenv:core-numpy-tests]usedevelop}
 deps =
     {[testenv:core-numpy-tests]deps}
@@ -31,12 +35,7 @@ commands =
     {[testenv:core-numpy-tests]commands}
 
 [testenv:torch-tests]
-# this environement runs Python tests with metatensor-torch
-
-# we use by default the cpu version of torch, if the cuda version is desired
-# please overwrite the PIP_EXTRA_INDEX_URL
-setenv =
-    PIP_EXTRA_INDEX_URL={env:PIP_EXTRA_INDEX_URL:https://download.pytorch.org/whl/cpu}
+description = Runs Python tests with metatensor-torch
 usedevelop = {[testenv:core-numpy-tests]usedevelop}
 extras = torch
 deps =
@@ -45,6 +44,7 @@ commands =
     {[testenv:core-numpy-tests]commands}
 
 [testenv:lint]
+description = Run linters
 skip_install = true
 deps =
     flake8
@@ -57,8 +57,9 @@ commands =
     isort --check-only --diff {[tox]lint_folders}
 
 [testenv:format]
-# Abuse tox to do actual formatting. Users can call `tox -e format` to run
-# formatting on all files
+description =
+    Abuse tox to do actual formatting. Users can call `tox -e format` to run
+    formatting on all files.
 skip_install = true
 deps =
     black
@@ -68,7 +69,7 @@ commands =
     isort {[tox]lint_folders}
 
 [testenv:docs]
-# this environement builds the documentation with sphinx
+description = Build the documentation with sphinx
 usedevelop = true
 setenv =
     PIP_EXTRA_INDEX_URL={env:PIP_EXTRA_INDEX_URL:https://download.pytorch.org/whl/cpu}
@@ -78,7 +79,7 @@ deps =
 commands = sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
 
 [testenv:build]
-# Make sure we can build sdist and a wheel for python
+description = Build sdist and a wheel for python
 deps =
     build
     check-manifest


### PR DESCRIPTION
Using builds from `https://luthaf.fr/nightly-wheels/` for the speading up the builds and allowing easier downstream usage. The makes the infrastructure code also much cleaner.

The env variable `PIP_EXTRA_INDEX_URL=https://luthaf.fr/nightly-wheels/` for RTD is set in their web interface because setting them in yml file is for whatever reasons not working...

<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--53.org.readthedocs.build/en/53/

<!-- readthedocs-preview equisolve end -->