### PR TITLE
Selection for equivariant tensors, and return Hausdorff distances

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = [
 requires-python = ">=3.7"
 
 dependencies = [
-    "equistore @ https://github.com/lab-cosmo/equistore/archive/c022fde.zip",
+    "equistore @ https://github.com/lab-cosmo/equistore/archive/47ce45b.zip",
     "numpy",
     "scipy",
     "skmatter"

--- a/src/equisolve/numpy/_selection.py
+++ b/src/equisolve/numpy/_selection.py
@@ -84,7 +84,7 @@ class GreedySelector:
             Whether the fit should continue after having already run, after
             increasing `n_to_select`. Assumes it is called with the same X.
         """
-        # CHeck that we have only 0 or 1 comoponent axes
+        # Check that we have only 0 or 1 comoponent axes
         if len(X.components_names) == 0:
             has_components = False
         elif len(X.components_names) == 1:

--- a/src/equisolve/numpy/_selection.py
+++ b/src/equisolve/numpy/_selection.py
@@ -5,7 +5,7 @@
 #
 # Released under the BSD 3-Clause "New" or "Revised" License
 # SPDX-License-Identifier: BSD-3-Clause
-from typing import Type
+from typing import Type, Union
 
 import equistore
 import numpy as np
@@ -25,14 +25,17 @@ class GreedySelector:
         self,
         selector_class: Type[skmatter._selection.GreedySelector],
         selection_type: str,
+        n_to_select: Union[int, dict],
         **selector_arguments,
     ) -> None:
         self._selector_class = selector_class
         self._selection_type = selection_type
+        self._n_to_select = n_to_select
         self._selector_arguments = selector_arguments
 
         self._selector_arguments["selection_type"] = self._selection_type
         self._support = None
+        self._select_distance = None
 
     @property
     def selector_class(self) -> Type[skmatter._selection.GreedySelector]:
@@ -57,6 +60,17 @@ class GreedySelector:
 
         return self._support
 
+    @property
+    def get_select_distance(self) -> TensorMap:
+        """TensorMap containing the Haussdorf distances."""
+        if self._support is None:
+            raise ValueError("No selections. Call fit method first.")
+        if self._select_distance is None:
+            raise ValueError("No Haussdorf distances. Call fit method first.")
+
+        return self._select_distance
+
+
     def fit(self, X: TensorMap, warm_start: bool = False) -> None:
         """Learn the features to select.
 
@@ -66,36 +80,122 @@ class GreedySelector:
             Whether the fit should continue after having already run, after increasing
             `n_to_select`. Assumes it is called with the same X.
         """
-        if len(X.components_names) != 0:
-            raise ValueError("Only blocks with no components are supported.")
+        # CHeck that we have only 0 or 1 comoponent axes
+        if len(X.components_names) == 0:
+            has_components = False
+        elif len(X.components_names) == 1:
+            has_components = True
+        else:
+            assert len(X.components_names) > 1
+            raise ValueError(
+                "Can only handle TensorMaps with a single component axis."
+            )
 
-        blocks = []
-        for _, block in X.items():
-            selector = self.selector_class(**self.selector_arguments)
-            selector.fit(block.values, warm_start=warm_start)
-            mask = selector.get_support()
+        support_blocks = []
+        haussdorf_blocks = []
+        for key, block in X.items():
+            # Parse the n_to_select argument
+            max_n = len(block.properties) if self._selection_type == "feature" else len(block.samples)
+            if isinstance(self._n_to_select, int):
+                if self._n_to_select == -1:  # set to the number of samples/features for this block
+                    tmp_n_to_select = max_n
+                else:
+                    tmp_n_to_select = self._n_to_select
+                    
+            elif isinstance(self._n_to_select, dict):
+                tmp_n_to_select = self._n_to_select[tuple(key.values)]
+            else:
+                raise ValueError("n_to_select must be an int or a dict.")
 
+            if not (0 < tmp_n_to_select <= max_n):
+                raise ValueError(
+                    f"n_to_select ({tmp_n_to_select}) must > 0 and <= the number of "
+                    f"{self._selection_type} for the given block ({max_n})."
+                )
+                
+            selector = self.selector_class(
+                n_to_select=tmp_n_to_select,
+                **self.selector_arguments
+            )
+
+            # If the block has components, reshape to a 2D array such that the
+            # components expand along the dimension *not* being selected.
+            block_vals = block.values
+            if has_components:
+                n_components = len(block.components[0])
+                if self._selection_type == "feature":
+                    # Move components into samples
+                    block_vals = block_vals.reshape(
+                        (
+                            block_vals.shape[0] * n_components, 
+                            block_vals.shape[2]
+                        )
+                    )
+                else:
+                    assert self._selection_type == "sample"
+                    # Move components into features
+                    block_vals = block.values.reshape(
+                        (
+                            block_vals.shape[0], 
+                            block_vals.shape[2] * n_components
+                        )
+                    )
+                
+            # Fit on the block values
+            selector.fit(block_vals, warm_start=warm_start)
+
+            # Build the support TensorMap. In this case we want the mask to be a
+            # list of bools, such that the original order of the metadata is
+            # preserved.
+            supp_mask = selector.get_support()
             if self._selection_type == "feature":
-                samples = Labels.single()
-                properties = Labels(
-                    names=block.properties.names, values=block.properties.values[mask]
+                supp_samples = Labels.single()
+                supp_properties = Labels(
+                    names=block.properties.names, values=block.properties.values[supp_mask]
                 )
             elif self._selection_type == "sample":
-                samples = Labels(
-                    names=block.samples.names, values=block.samples.values[mask]
+                supp_samples = Labels(
+                    names=block.samples.names, values=block.samples.values[supp_mask]
                 )
-                properties = Labels.single()
+                supp_properties = Labels.single()
 
-            blocks.append(
+            supp_vals = np.zeros([len(supp_samples), len(supp_properties)], dtype=np.int32)
+            support_blocks.append(
                 TensorBlock(
-                    values=np.zeros([len(samples), len(properties)], dtype=np.int32),
-                    samples=samples,
+                    values=supp_vals,
+                    samples=supp_samples,
                     components=[],
-                    properties=properties,
+                    properties=supp_properties,
                 )
             )
 
-        self._support = TensorMap(X.keys, blocks)
+            # Build the Haussdorf TensorMap. In this case we want the mask to be a
+            # list of int such that the smaples/properties are reordered
+            # according to the Haussdorf distance.
+            haus_mask = selector.get_support(indices=True, ordered=True)
+            if self._selection_type == "feature":
+                haus_samples = Labels.single()
+                haus_properties = Labels(
+                    names=block.properties.names, values=block.properties.values[haus_mask]
+                )
+            elif self._selection_type == "sample":
+                haus_samples = Labels(
+                    names=block.samples.names, values=block.samples.values[haus_mask]
+                )
+                haus_properties = Labels.single()
+            
+            haus_vals = selector.haussdorf_at_select_[haus_mask].reshape(len(haus_samples), len(haus_properties))
+            haussdorf_blocks.append(
+                TensorBlock(
+                    values=haus_vals,
+                    samples=haus_samples,
+                    components=[],
+                    properties=haus_properties,
+                )
+            )
+
+        self._support = TensorMap(X.keys, support_blocks)
+        self._select_distance = TensorMap(X.keys, haussdorf_blocks)
 
         return self
 

--- a/src/equisolve/numpy/_selection.py
+++ b/src/equisolve/numpy/_selection.py
@@ -68,8 +68,8 @@ class GreedySelector:
         whether sample or feature selection is being performed) is sorted
         according to the Hausdorff distance, in descending order.
         """
-        if self._support is None:
-            raise ValueError("No selections. Call fit method first.")
+        if self._selector_class == skmatter._selection._CUR:
+            raise ValueError("Hausdorff distances not available for CUR in skmatter.")
         if self._select_distance is None:
             raise ValueError("No Hausdorff distances. Call fit method first.")
 

--- a/src/equisolve/numpy/feature_selection.py
+++ b/src/equisolve/numpy/feature_selection.py
@@ -19,11 +19,11 @@ class FPS(GreedySelector):
     """
     Transformer that performs Greedy Feature Selection using Farthest Point
     Sampling.
-    
+
     If `n_to_select` is an `int`, all blocks will have this many features
     selected. In this case, `n_to_select` must be <= than the fewest number of
-    features in any block. 
-    
+    features in any block.
+
     If `n_to_select` is a dict, it must have keys that are tuples corresponding
     to the key values of each block. In this case, the values of the
     `n_to_select` dict can be int that specify different number of features to
@@ -65,8 +65,8 @@ class CUR(GreedySelector):
 
     If `n_to_select` is an `int`, all blocks will have this many features
     selected. In this case, `n_to_select` must be <= than the fewest number of
-    features in any block. 
-    
+    features in any block.
+
     If `n_to_select` is a dict, it must have keys that are tuples corresponding
     to the key values of each block. In this case, the values of the
     `n_to_select` dict can be int that specify different number of features to

--- a/src/equisolve/numpy/feature_selection.py
+++ b/src/equisolve/numpy/feature_selection.py
@@ -30,7 +30,7 @@ class FPS(GreedySelector):
     select for each block.
 
     If `n_to_select` is -1, all features for every block will be selected. This
-    is useful, for instance, for plotting Haussdorf distances, which can be
+    is useful, for instance, for plotting Hausdorff distances, which can be
     accessed through the selector.haussdorf_at_select property after calling the
     fit() method.
 
@@ -73,7 +73,7 @@ class CUR(GreedySelector):
     select for each block.
 
     If `n_to_select` is -1, all features for every block will be selected. This
-    is useful, for instance, for plotting Haussdorf distances, which can be
+    is useful, for instance, for plotting Hausdorff distances, which can be
     accessed through the selector.haussdorf_at_select property after calling the
     fit() method.
 

--- a/src/equisolve/numpy/feature_selection.py
+++ b/src/equisolve/numpy/feature_selection.py
@@ -72,10 +72,7 @@ class CUR(GreedySelector):
     `n_to_select` dict can be int that specify different number of features to
     select for each block.
 
-    If `n_to_select` is -1, all features for every block will be selected. This
-    is useful, for instance, for plotting Hausdorff distances, which can be
-    accessed through the selector.haussdorf_at_select property after calling the
-    fit() method.
+    If `n_to_select` is -1, all features for every block will be selected.
 
     Refer to :py:class:`skmatter.feature_selection.CUR` for full documentation.
     """

--- a/src/equisolve/numpy/feature_selection.py
+++ b/src/equisolve/numpy/feature_selection.py
@@ -17,7 +17,22 @@ from ._selection import GreedySelector
 
 class FPS(GreedySelector):
     """
-    Transformer that performs Greedy Feature Selection using Farthest Point Sampling.
+    Transformer that performs Greedy Feature Selection using Farthest Point
+    Sampling.
+    
+    If `n_to_select` is an `int`, all blocks will have this many features
+    selected. In this case, `n_to_select` must be <= than the fewest number of
+    features in any block. 
+    
+    If `n_to_select` is a dict, it must have keys that are tuples corresponding
+    to the key values of each block. In this case, the values of the
+    `n_to_select` dict can be int that specify different number of features to
+    select for each block.
+
+    If `n_to_select` is -1, all features for every block will be selected. This
+    is useful, for instance, for plotting Haussdorf distances, which can be
+    accessed through the selector.haussdorf_at_select property after calling the
+    fit() method.
 
     Refer to :py:class:`skmatter.feature_selection.FPS` for full documentation.
     """
@@ -47,6 +62,20 @@ class FPS(GreedySelector):
 
 class CUR(GreedySelector):
     """Transformer that performs Greedy Feature Selection with CUR.
+
+    If `n_to_select` is an `int`, all blocks will have this many features
+    selected. In this case, `n_to_select` must be <= than the fewest number of
+    features in any block. 
+    
+    If `n_to_select` is a dict, it must have keys that are tuples corresponding
+    to the key values of each block. In this case, the values of the
+    `n_to_select` dict can be int that specify different number of features to
+    select for each block.
+
+    If `n_to_select` is -1, all features for every block will be selected. This
+    is useful, for instance, for plotting Haussdorf distances, which can be
+    accessed through the selector.haussdorf_at_select property after calling the
+    fit() method.
 
     Refer to :py:class:`skmatter.feature_selection.CUR` for full documentation.
     """

--- a/src/equisolve/numpy/sample_selection.py
+++ b/src/equisolve/numpy/sample_selection.py
@@ -19,11 +19,11 @@ class FPS(GreedySelector):
     """
     Transformer that performs Greedy Sample Selection using Farthest Point
     Sampling.
-    
+
     If `n_to_select` is an `int`, all blocks will have this many samples
     selected. In this case, `n_to_select` must be <= than the fewest number of
-    samples in any block. 
-    
+    samples in any block.
+
     If `n_to_select` is a dict, it must have keys that are tuples corresponding
     to the key values of each block. In this case, the values of the
     `n_to_select` dict can be int that specify different number of samples to
@@ -65,8 +65,8 @@ class CUR(GreedySelector):
 
     If `n_to_select` is an `int`, all blocks will have this many samples
     selected. In this case, `n_to_select` must be <= than the fewest number of
-    samples in any block. 
-    
+    samples in any block.
+
     If `n_to_select` is a dict, it must have keys that are tuples corresponding
     to the key values of each block. In this case, the values of the
     `n_to_select` dict can be int that specify different number of samples to

--- a/src/equisolve/numpy/sample_selection.py
+++ b/src/equisolve/numpy/sample_selection.py
@@ -72,10 +72,7 @@ class CUR(GreedySelector):
     `n_to_select` dict can be int that specify different number of samples to
     select for each block.
 
-    If `n_to_select` is -1, all samples for every block will be selected. This
-    is useful, for instance, for plotting Hausdorff distances, which can be
-    accessed through the selector.haussdorf_at_select property method after
-    calling the fit() method.
+    If `n_to_select` is -1, all samples for every block will be selected.
 
     Refer to :py:class:`skmatter.sample_selection.CUR` for full documentation.
     """

--- a/src/equisolve/numpy/sample_selection.py
+++ b/src/equisolve/numpy/sample_selection.py
@@ -30,7 +30,7 @@ class FPS(GreedySelector):
     select for each block.
 
     If `n_to_select` is -1, all samples for every block will be selected. This
-    is useful, for instance, for plotting Haussdorf distances, which can be
+    is useful, for instance, for plotting Hausdorff distances, which can be
     accessed through the selector.haussdorf_at_select property method after
     calling the fit() method.
 
@@ -73,7 +73,7 @@ class CUR(GreedySelector):
     select for each block.
 
     If `n_to_select` is -1, all samples for every block will be selected. This
-    is useful, for instance, for plotting Haussdorf distances, which can be
+    is useful, for instance, for plotting Hausdorff distances, which can be
     accessed through the selector.haussdorf_at_select property method after
     calling the fit() method.
 

--- a/src/equisolve/numpy/sample_selection.py
+++ b/src/equisolve/numpy/sample_selection.py
@@ -17,7 +17,22 @@ from ._selection import GreedySelector
 
 class FPS(GreedySelector):
     """
-    Transformer that performs Greedy Sample Selection using Farthest Point Sampling.
+    Transformer that performs Greedy Sample Selection using Farthest Point
+    Sampling.
+    
+    If `n_to_select` is an `int`, all blocks will have this many samples
+    selected. In this case, `n_to_select` must be <= than the fewest number of
+    samples in any block. 
+    
+    If `n_to_select` is a dict, it must have keys that are tuples corresponding
+    to the key values of each block. In this case, the values of the
+    `n_to_select` dict can be int that specify different number of samples to
+    select for each block.
+
+    If `n_to_select` is -1, all samples for every block will be selected. This
+    is useful, for instance, for plotting Haussdorf distances, which can be
+    accessed through the selector.haussdorf_at_select property method after
+    calling the fit() method.
 
     Refer to :py:class:`skmatter.sample_selection.FPS` for full documentation.
     """
@@ -47,6 +62,20 @@ class FPS(GreedySelector):
 
 class CUR(GreedySelector):
     """Transformer that performs Greedy Sample Selection using CUR.
+
+    If `n_to_select` is an `int`, all blocks will have this many samples
+    selected. In this case, `n_to_select` must be <= than the fewest number of
+    samples in any block. 
+    
+    If `n_to_select` is a dict, it must have keys that are tuples corresponding
+    to the key values of each block. In this case, the values of the
+    `n_to_select` dict can be int that specify different number of samples to
+    select for each block.
+
+    If `n_to_select` is -1, all samples for every block will be selected. This
+    is useful, for instance, for plotting Haussdorf distances, which can be
+    accessed through the selector.haussdorf_at_select property method after
+    calling the fit() method.
 
     Refer to :py:class:`skmatter.sample_selection.CUR` for full documentation.
     """

--- a/tests/equisolve_tests/numpy/feature_selection.py
+++ b/tests/equisolve_tests/numpy/feature_selection.py
@@ -111,7 +111,7 @@ class TestSelection:
         selector.fit(X2)
         select_distance = selector.get_select_distance
         for i, key in enumerate(keys):
-            assert len(block.properties) == 2 * i + 1
+            assert len(select_distance[key].properties) == 2 * i + 1
 
     @pytest.mark.parametrize("selector_class", [CUR])
     def test_get_select_distance_raises(self, X2, selector_class):

--- a/tests/equisolve_tests/numpy/feature_selection.py
+++ b/tests/equisolve_tests/numpy/feature_selection.py
@@ -10,29 +10,36 @@ import numpy as np
 import pytest
 import skmatter.feature_selection
 from metatensor import Labels
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_raises
 
 from equisolve.numpy.feature_selection import CUR, FPS
 
-from .utilities import random_single_block_no_components_tensor_map
+from .utilities import (
+    random_single_block_no_components_tensor_map,
+    random_tensor_map_with_components,
+)
 
 
 class TestSelection:
     @pytest.fixture
-    def X(self):
+    def X1(self):
         return random_single_block_no_components_tensor_map()
+
+    @pytest.fixture
+    def X2(self):
+        return random_tensor_map_with_components()
 
     @pytest.mark.parametrize(
         "selector_class, skmatter_selector_class",
         [(FPS, skmatter.feature_selection.FPS), (CUR, skmatter.feature_selection.CUR)],
     )
-    def test_fit(self, X, selector_class, skmatter_selector_class):
+    def test_fit(self, X1, selector_class, skmatter_selector_class):
         selector = selector_class(n_to_select=2)
-        selector.fit(X)
+        selector.fit(X1)
         support = selector.support[0].properties
 
         skmatter_selector = skmatter_selector_class(n_to_select=2)
-        skmatter_selector.fit(X[0].values)
+        skmatter_selector.fit(X1[0].values)
         skmatter_support = skmatter_selector.get_support(indices=True)
         skmatter_support_labels = Labels(
             names=["properties"],
@@ -47,20 +54,68 @@ class TestSelection:
         "selector_class, skmatter_selector_class",
         [(FPS, skmatter.feature_selection.FPS), (CUR, skmatter.feature_selection.CUR)],
     )
-    def test_transform(self, X, selector_class, skmatter_selector_class):
+    def test_transform(self, X1, selector_class, skmatter_selector_class):
         selector = selector_class(n_to_select=2)
-        selector.fit(X)
-        X_trans = selector.transform(X)
+        selector.fit(X1)
+        X_trans = selector.transform(X1)
 
         skmatter_selector = skmatter_selector_class(n_to_select=2)
-        skmatter_selector.fit(X[0].values)
-        X_trans_skmatter = skmatter_selector.transform(X[0].values)
+        skmatter_selector.fit(X1[0].values)
+        X_trans_skmatter = skmatter_selector.transform(X1[0].values)
 
         assert_equal(X_trans[0].values, X_trans_skmatter)
 
     @pytest.mark.parametrize("selector_class", [FPS, CUR])
-    def test_fit_transform(self, X, selector_class):
+    def test_fit_transform(self, X1, selector_class):
         selector = selector_class(n_to_select=2)
 
-        X_ft = selector.fit(X).transform(X)
-        metatensor.equal_raise(selector.fit_transform(X), X_ft)
+        X_ft = selector.fit(X1).transform(X1)
+        metatensor.equal_raise(selector.fit_transform(X1), X_ft)
+
+    @pytest.mark.parametrize("selector_class", [FPS])
+    def test_get_select_distance(self, X2, selector_class):
+        selector = selector_class(n_to_select=3)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+
+        assert select_distance is not None
+
+        # Check distances sorted in descending order, with an inf as the first
+        # entry
+        for block in select_distance:
+            assert block.values[0][0] == np.inf
+            for i, val in enumerate(block.values[0][1:], start=1):
+                assert val < block.values[0][i - 1]
+
+    @pytest.mark.parametrize("selector_class", [FPS])
+    def test_get_select_distance_n_to_select(self, X2, selector_class):
+        # Case 1: select all features for every block (n_to_select = -1)
+        selector = selector_class(n_to_select=-1)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+        for block in select_distance:
+            assert len(block.properties) == 5
+
+        # Case 2: select subset of features but same for each block
+        n = 2
+        selector = selector_class(n_to_select=n)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+        for block in select_distance:
+            assert len(block.properties) == n
+
+        # Case 3: select subset of features but different for each block
+        keys = X2.keys
+        n = {tuple(key): 2 * i + 1 for i, key in enumerate(keys)}
+        selector = selector_class(n_to_select=n)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+        for i, key in enumerate(keys):
+            assert len(block.properties) == 2 * i + 1
+
+    @pytest.mark.parametrize("selector_class", [CUR])
+    def test_get_select_distance_raises(self, X2, selector_class):
+        selector = selector_class(n_to_select=3)
+        selector.fit(X2)
+        with assert_raises(ValueError):
+            selector.get_select_distance

--- a/tests/equisolve_tests/numpy/sample_selection.py
+++ b/tests/equisolve_tests/numpy/sample_selection.py
@@ -10,29 +10,36 @@ import numpy as np
 import pytest
 import skmatter.sample_selection
 from metatensor import Labels
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_raises
 
 from equisolve.numpy.sample_selection import CUR, FPS
 
-from .utilities import random_single_block_no_components_tensor_map
+from .utilities import (
+    random_single_block_no_components_tensor_map,
+    random_tensor_map_with_components,
+)
 
 
 class TestSelection:
     @pytest.fixture
-    def X(self):
+    def X1(self):
         return random_single_block_no_components_tensor_map()
+
+    @pytest.fixture
+    def X2(self):
+        return random_tensor_map_with_components()
 
     @pytest.mark.parametrize(
         "selector_class, skmatter_selector_class",
         [(FPS, skmatter.sample_selection.FPS), (CUR, skmatter.sample_selection.CUR)],
     )
-    def test_fit(self, X, selector_class, skmatter_selector_class):
+    def test_fit(self, X1, selector_class, skmatter_selector_class):
         selector = selector_class(n_to_select=2)
-        selector.fit(X)
+        selector.fit(X1)
         support = selector.support[0].samples
 
         skmatter_selector = skmatter_selector_class(n_to_select=2)
-        skmatter_selector.fit(X[0].values)
+        skmatter_selector.fit(X1[0].values)
         skmatter_support = skmatter_selector.get_support(indices=True)
         skmatter_support_labels = Labels(
             names=["sample", "structure"],
@@ -48,19 +55,67 @@ class TestSelection:
         "selector_class, skmatter_selector_class",
         [(FPS, skmatter.sample_selection.FPS), (CUR, skmatter.sample_selection.CUR)],
     )
-    def test_transform(self, X, selector_class, skmatter_selector_class):
+    def test_transform(self, X1, selector_class, skmatter_selector_class):
         selector = selector_class(n_to_select=2, random_state=0)
-        selector.fit(X)
-        X_trans = selector.transform(X)
+        selector.fit(X1)
+        X_trans = selector.transform(X1)
 
         skmatter_selector = skmatter_selector_class(n_to_select=2, random_state=0)
-        skmatter_selector.fit(X[0].values)
-        X_trans_skmatter = X[0].values[skmatter_selector.get_support()]
+        skmatter_selector.fit(X1[0].values)
+        X_trans_skmatter = X1[0].values[skmatter_selector.get_support()]
         assert_equal(X_trans[0].values, X_trans_skmatter)
 
     @pytest.mark.parametrize("selector_class", [FPS, CUR])
-    def test_fit_transform(self, X, selector_class):
+    def test_fit_transform(self, X1, selector_class):
         selector = selector_class(n_to_select=2)
 
-        X_ft = selector.fit(X).transform(X)
-        metatensor.equal_raise(selector.fit_transform(X), X_ft)
+        X_ft = selector.fit(X1).transform(X1)
+        metatensor.equal_raise(selector.fit_transform(X1), X_ft)
+
+    @pytest.mark.parametrize("selector_class", [FPS])
+    def test_get_select_distance(self, X2, selector_class):
+        selector = selector_class(n_to_select=3)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+
+        assert select_distance is not None
+
+        # Check distances sorted in descending order, with an inf as the first
+        # entry
+        for block in select_distance:
+            assert block.values[0][0] == np.inf
+            for i, val in enumerate(block.values[0][1:], start=1):
+                assert val < block.values[0][i - 1]
+
+    @pytest.mark.parametrize("selector_class", [FPS])
+    def test_get_select_distance_n_to_select(self, X2, selector_class):
+        # Case 1: select all features for every block (n_to_select = -1)
+        selector = selector_class(n_to_select=-1)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+        for block in select_distance:
+            assert len(block.samples) == 4
+
+        # Case 2: select subset of features but same for each block
+        n = 2
+        selector = selector_class(n_to_select=n)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+        for block in select_distance:
+            assert len(block.samples) == n
+
+        # Case 3: select subset of features but different for each block
+        keys = X2.keys
+        n = {tuple(key): i for i, key in enumerate(keys, start=1)}
+        selector = selector_class(n_to_select=n)
+        selector.fit(X2)
+        select_distance = selector.get_select_distance
+        for i, key in enumerate(keys, start=1):
+            assert len(select_distance[key].samples) == i
+
+    @pytest.mark.parametrize("selector_class", [CUR])
+    def test_get_select_distance_raises(self, X2, selector_class):
+        selector = selector_class(n_to_select=3)
+        selector.fit(X2)
+        with assert_raises(ValueError):
+            selector.get_select_distance

--- a/tests/equisolve_tests/numpy/utilities.py
+++ b/tests/equisolve_tests/numpy/utilities.py
@@ -4,11 +4,20 @@ import metatensor
 import numpy as np
 from metatensor import Labels, TensorMap
 
-from ..utilities import random_single_block_no_components_tensor_map
+from ..utilities import (
+    random_single_block_no_components_tensor_map,
+    random_tensor_map_with_components,
+)
 
 
 random_single_block_no_components_tensor_map = functools.partial(
     random_single_block_no_components_tensor_map,
+    use_torch=False,
+    use_metatensor_torch=False,
+)
+
+random_tensor_map_with_components = functools.partial(
+    random_tensor_map_with_components,
     use_torch=False,
     use_metatensor_torch=False,
 )

--- a/tests/equisolve_tests/utilities.py
+++ b/tests/equisolve_tests/utilities.py
@@ -119,7 +119,9 @@ def random_tensor_map_with_components(use_torch, use_metatensor_torch):
             components=[
                 Labels(names=["component"], values=np.arange(2 * i + 1).reshape(-1, 1)),
             ],
-            properties=Labels(["properties"], create_int32_array([[0], [1], [2], [5], [10]])),
+            properties=Labels(
+                ["properties"], create_int32_array([[0], [1], [2], [5], [10]])
+            ),
         )
         positions_gradient = TensorBlock(
             values=create_random_array(7, 3, 2 * i + 1, 5),

--- a/tests/equisolve_tests/utilities.py
+++ b/tests/equisolve_tests/utilities.py
@@ -79,7 +79,7 @@ def random_single_block_no_components_tensor_map(use_torch, use_metatensor_torch
     return TensorMap(Labels.single(), [block_1])
 
 
-def random_single_block_with_components_tensor_map(use_torch, use_metatensor_torch):
+def random_tensor_map_with_components(use_torch, use_metatensor_torch):
     """
     Create a dummy tensor map to be used in tests. This is the same one as the
     tensor map used in `tensor.rs` tests.
@@ -111,7 +111,7 @@ def random_single_block_with_components_tensor_map(use_torch, use_metatensor_tor
     blocks = []
     for i in range(3):
         block = TensorBlock(
-            values=create_random_array(4, 2 * i + 1, 2),
+            values=create_random_array(4, 2 * i + 1, 5),
             samples=Labels(
                 ["sample", "structure"],
                 create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
@@ -119,10 +119,10 @@ def random_single_block_with_components_tensor_map(use_torch, use_metatensor_tor
             components=[
                 Labels(names=["component"], values=np.arange(2 * i + 1).reshape(-1, 1)),
             ],
-            properties=Labels(["properties"], create_int32_array([[0], [1]])),
+            properties=Labels(["properties"], create_int32_array([[0], [1], [2], [5], [10]])),
         )
         positions_gradient = TensorBlock(
-            values=create_random_array(7, 3, 2 * i + 1, 2),
+            values=create_random_array(7, 3, 2 * i + 1, 5),
             samples=Labels(
                 ["sample", "structure", "center"],
                 create_int32_array(
@@ -146,7 +146,7 @@ def random_single_block_with_components_tensor_map(use_torch, use_metatensor_tor
         block.add_gradient("positions", positions_gradient)
 
         cell_gradient = TensorBlock(
-            values=create_random_array(4, 6, 2 * i + 1, 2),
+            values=create_random_array(4, 6, 2 * i + 1, 5),
             samples=Labels(
                 ["sample", "structure"],
                 create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),

--- a/tests/equisolve_tests/utilities.py
+++ b/tests/equisolve_tests/utilities.py
@@ -77,3 +77,90 @@ def random_single_block_no_components_tensor_map(use_torch, use_metatensor_torch
     block_1.add_gradient("cell", cell_gradient)
 
     return TensorMap(Labels.single(), [block_1])
+
+
+def random_single_block_with_components_tensor_map(use_torch, use_metatensor_torch):
+    """
+    Create a dummy tensor map to be used in tests. This is the same one as the
+    tensor map used in `tensor.rs` tests.
+    """
+    if not use_torch and use_metatensor_torch:
+        raise ValueError(
+            "torch.TensorMap cannot be created without torch.Tensor block values."
+        )
+    if use_metatensor_torch:
+        import torch
+        from metatensor.torch import Labels, TensorBlock, TensorMap
+
+        create_int32_array = functools.partial(torch.tensor, dtype=torch.int32)
+    else:
+        import numpy as np
+        from metatensor import Labels, TensorBlock, TensorMap
+
+        create_int32_array = functools.partial(np.array, dtype=np.int32)
+
+    if use_torch:
+        import torch
+
+        create_random_array = torch.rand
+    else:
+        import numpy as np
+
+        create_random_array = np.random.rand
+
+    blocks = []
+    for i in range(3):
+        block = TensorBlock(
+            values=create_random_array(4, 2 * i + 1, 2),
+            samples=Labels(
+                ["sample", "structure"],
+                create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+            ),
+            components=[
+                Labels(names=["component"], values=np.arange(2 * i + 1).reshape(-1, 1)),
+            ],
+            properties=Labels(["properties"], create_int32_array([[0], [1]])),
+        )
+        positions_gradient = TensorBlock(
+            values=create_random_array(7, 3, 2 * i + 1, 2),
+            samples=Labels(
+                ["sample", "structure", "center"],
+                create_int32_array(
+                    [
+                        [0, 0, 1],
+                        [0, 0, 2],
+                        [1, 1, 0],
+                        [1, 1, 1],
+                        [1, 1, 2],
+                        [2, 2, 0],
+                        [3, 3, 0],
+                    ],
+                ),
+            ),
+            components=[
+                Labels(["direction"], create_int32_array([[0], [1], [2]])),
+                Labels(names=["component"], values=np.arange(2 * i + 1).reshape(-1, 1)),
+            ],
+            properties=block.properties,
+        )
+        block.add_gradient("positions", positions_gradient)
+
+        cell_gradient = TensorBlock(
+            values=create_random_array(4, 6, 2 * i + 1, 2),
+            samples=Labels(
+                ["sample", "structure"],
+                create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+            ),
+            components=[
+                Labels(
+                    ["direction_xx_yy_zz_yz_xz_xy"],
+                    create_int32_array([[0], [1], [2], [3], [4], [5]]),
+                ),
+                Labels(names=["component"], values=np.arange(2 * i + 1).reshape(-1, 1)),
+            ],
+            properties=block.properties,
+        )
+        block.add_gradient("cell", cell_gradient)
+        blocks.append(block)
+
+    return TensorMap(Labels(names=["key"], values=np.arange(3).reshape(-1, 1)), blocks)


### PR DESCRIPTION
- Modifies the `GreedySelector.fit` method to allow for TensorMaps with a single components axis (i.e. equivariants)
- Allows the user to pass either an `int` or `dict` for `n_to_select`. Setting to an int sets a fixed value for every block. Setting to -1 sets to the maximum number of samples/features for each block. Setting to a dict allows explicit control of the number of selection points for each block
- Returns the sorted Haussdorf distances in the `selector.get_select_distance` property.

For instance, one can plot sorted Haussdorf distances for the features of each block as follows:

```python
import matplotlib.pyplot as plt
import numpy as np

import equistore
from equisolve.numpy import feature_selection

tensor = equistore.load("tensor.npz")

# n_to_select = 10  # set num features to 10 for every block
n_to_select = -1  # set to the max for each block
# n_to_select = {  
#     tuple(key.values): len(block.properties) - np.random.randint(0, 2)
#     for key, block in tensor.items()
# }  # control for each block

selector = feature_selection.FPS(n_to_select=n_to_select, initialize="random")
tensor_fps = selector.fit_transform(tensor)

fig, ax = plt.subplots()
for key, block in selector.get_select_distance.items():
    ax.loglog(np.sort(block.values.flatten())[::-1], label=key)

fig.legend()
```

Still to do:

- [x] Update tests


<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--59.org.readthedocs.build/en/59/

<!-- readthedocs-preview equisolve end -->