### PR TITLE
add neural network modules that work with tensor maps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,14 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: pip install tox
 
-    - name: run Python tests
-      run: tox -e tests
+    - name: run Python metatensor-core tests wtih numpy array backend
+      run: tox -e core-numpy-tests
+
+    - name: run Python metatensor-core tests with torch array backend
+      run: tox -e core-torch-tests
+
+    - name: run Python metatensor-torch tests
+      run: tox -e torch-tests
 
     - name: try building Python wheel and sdist
       run: tox -e build

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,6 @@ python:
    install:
    - method: pip
      path: .
+     extra_requirements:
+       - torch
    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,6 @@ furo
 #
 # When we update the metatensor hash here we ALSO have to update the hash
 # in the rascaline branch!
-rascaline @ https://github.com/luthaf/rascaline/archive/fb5332f.zip
+rascaline @ https://github.com/luthaf/rascaline/archive/23448bd.zip
 sphinx >=4.4
 sphinx-gallery

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -16,6 +16,10 @@ import equisolve
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
+# when importing metatensor-torch, this will change the definition of the classes
+# to include the documentation
+os.environ["METATENSOR_IMPORT_FOR_SPHINX"] = "1"
+
 sys.path.insert(0, os.path.abspath('../../'))
 
 # -- Project information -----------------------------------------------------

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -192,6 +192,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     "skmatter": ("https://scikit-matter.readthedocs.io/en/latest/", None),
+    "torch": ("https://pytorch.org/docs/master/", None),
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/src/reference/index.rst
+++ b/docs/src/reference/index.rst
@@ -16,3 +16,4 @@ recipes how to stack the functions toegther you might take a look at the
     selection/index.rst
     models
     utils/index
+    neural_network

--- a/docs/src/reference/neural_network.rst
+++ b/docs/src/reference/neural_network.rst
@@ -1,0 +1,5 @@
+Neural Network
+==============
+
+.. automodule:: equisolve.nn
+    :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = [
 requires-python = ">=3.7"
 
 dependencies = [
-    "metatensor @ https://github.com/lab-cosmo/metatensor/archive/3c5fee4.zip",
+    "metatensor @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip",
     "numpy",
     "scipy",
     "skmatter"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "scipy",
     "skmatter"
 ]
+[project.optional-dependencies]
+torch = ["metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip"]
 
 [project.urls]
 homepage = "https://lab-cosmo.github.io/equisolve/latest/"

--- a/src/equisolve/nn/__init__.py
+++ b/src/equisolve/nn/__init__.py
@@ -1,0 +1,13 @@
+try:
+    import torch  # noqa: F401
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+if HAS_TORCH:
+    from .module_tensor import Linear, ModuleTensorMap  # noqa: F401
+
+    __all__ = ["Linear", "ModuleTensorMap"]
+else:
+    __all__ = []

--- a/src/equisolve/nn/module_tensor.py
+++ b/src/equisolve/nn/module_tensor.py
@@ -1,0 +1,236 @@
+try:
+    from metatensor.torch import Labels, LabelsEntry, TensorBlock, TensorMap
+
+    HAS_METATENSOR_TORCH = True
+except ImportError:
+    from metatensor import Labels, TensorBlock, TensorMap
+    from metatensor.core.labels import LabelsEntry
+
+    HAS_METATENSOR_TORCH = False
+
+from copy import deepcopy
+from typing import List, Optional
+
+import torch
+from torch.nn import Module, ModuleDict
+
+
+@torch.jit.interface
+class ModuleTensorMapInterface(torch.nn.Module):
+    """
+    This interface required for TorchScript to index the :py:class:`torch.nn.ModuleDict`
+    with non-literals in ModuleTensorMap. Any module that is used with ModuleTensorMap
+    must implement this interface to be TorchScript compilable.
+
+    Note that the *typings and argument names must match exactly* so that an interface
+    is correctly implemented.
+
+    Reference
+    ---------
+    https://github.com/pytorch/pytorch/pull/45716
+    """
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        pass
+
+
+class ModuleTensorMap(Module):
+    """
+    A wrapper around a :py:class:`torch.nn.ModuleDict` to apply each module to the
+    corresponding tensor block in the map using the dict key.
+
+    :param module_map:
+        A dictionary of modules with tensor map keys as dict keys
+        each module is applied on a block
+
+    :param out_tensor:
+        A tensor map that is used to determine the properties labels of the output.
+        Because an arbitrary module can change the number of properties, the labels of
+        the properties cannot be persevered. By default the output properties are
+        relabeled using Labels.range.
+    """
+
+    def __init__(self, module_map: ModuleDict, out_tensor: Optional[TensorMap] = None):
+        super().__init__()
+        self._module_map = module_map
+        # copy to prevent undefined behavior due to inplace changes
+        if out_tensor is not None:
+            out_tensor = out_tensor.copy()
+        self._out_tensor = out_tensor
+
+    @classmethod
+    def from_module(
+        cls,
+        in_keys: Labels,
+        module: Module,
+        many_to_one: bool = True,
+        out_tensor: Optional[TensorMap] = None,
+    ):
+        """
+        A wrapper around one :py:class:`torch.nn.Module` applying the same type of
+        module on each tensor block.
+
+        :param in_keys:
+            The keys that are assumed to be in the input tensor map in the
+            :py:meth:`forward` function.
+        :param module:
+            The module that is applied on each block.
+        :param many_to_one:
+            Specifies if a separate module for each block is used. If `True` the module
+            is deep copied for each key in the :py:attr:`in_keys`.
+        :param out_tensor:
+            A tensor map that is used to determine the properties labels of the output.
+            Because an arbitrary module can change the number of properties, the labels
+            of the properties cannot be persevered. By default the output properties are
+            relabeled using Labels.range.
+        """
+        module = deepcopy(module)
+        module_map = ModuleDict()
+        for key in in_keys:
+            module_key = ModuleTensorMap.module_key(key)
+            if many_to_one:
+                module_map[module_key] = module
+            else:
+                module_map[module_key] = deepcopy(module)
+
+        return cls(module_map, out_tensor)
+
+    def forward(self, tensor: TensorMap) -> TensorMap:
+        """
+        Takes a tensor map and applies the modules on each key it.
+
+        :param tensor:
+            input tensor map
+        """
+        out_blocks: List[TensorBlock] = []
+        for key, block in tensor.items():
+            out_block = self.forward_block(key, block)
+
+            for parameter, gradient in block.gradients():
+                if len(gradient.gradients_list()) != 0:
+                    raise NotImplementedError(
+                        "gradients of gradients are not supported"
+                    )
+                out_block.add_gradient(
+                    parameter=parameter,
+                    gradient=self.forward_block(key, gradient),
+                )
+            out_blocks.append(out_block)
+
+        return TensorMap(tensor.keys, out_blocks)
+
+    def forward_block(self, key: LabelsEntry, block: TensorBlock) -> TensorBlock:
+        module_key: str = ModuleTensorMap.module_key(key)
+        module: ModuleTensorMapInterface = self._module_map[module_key]
+        out_values = module.forward(block.values)
+        if self._out_tensor is None:
+            properties = Labels.range("_", out_values.shape[-1])
+        else:
+            properties = self._out_tensor.block(key).properties
+        return TensorBlock(
+            values=out_values,
+            properties=properties,
+            components=block.components,
+            samples=block.samples,
+        )
+
+    @property
+    def module_map(self):
+        """
+        The :py:class:`torch.nn.ModuleDict` that maps hashed module keys to a module
+        (see :py:func:`ModuleTensorMap.module_key`)
+        """
+        # type annotation in function signature had to be removed because of TorchScript
+        return self._module_map
+
+    @property
+    def out_tensor(self) -> Optional[TensorMap]:
+        """
+        The tensor map that is used to determine properties labels of the output of
+        forward function.
+        """
+        return self._out_tensor
+
+    @staticmethod
+    def module_key(key: LabelsEntry) -> str:
+        return str(key)
+
+
+class Linear(ModuleTensorMap):
+    """
+    :param in_tensor:
+        A tensor map that will be accepted in the :py:meth:`forward` function. It is
+        used to determine the keys input shape, device and dtype of the input to create
+        linear modules for tensor maps.
+
+    :param out_tensor:
+        A tensor map that is used to determine the properties labels and shape of the
+        output tensor map.  Because a linear module can change the number of
+        properties, the labels of the properties cannot be persevered.
+
+    :param bias:
+        See :py:class:`torch.nn.Linear`
+    """
+
+    def __init__(
+        self,
+        in_tensor: TensorMap,
+        out_tensor: TensorMap,
+        bias: bool = True,
+    ):
+        module_map = ModuleDict()
+        for key, in_block in in_tensor.items():
+            module_key = ModuleTensorMap.module_key(key)
+            out_block = out_tensor.block(key)
+            module = torch.nn.Linear(
+                len(in_block.properties),
+                len(out_block.properties),
+                bias,
+                in_block.values.device,
+                in_block.values.dtype,
+            )
+            module_map[module_key] = module
+
+        super().__init__(module_map, out_tensor)
+
+    @classmethod
+    def from_module(
+        cls,
+        in_keys: Labels,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        device: torch.device = None,
+        dtype: torch.dtype = None,
+        many_to_one: bool = True,
+        out_tensor: Optional[TensorMap] = None,
+    ):
+        """
+        :param in_keys:
+            The keys that are assumed to be in the input tensor map in the
+            :py:meth:`forward` function.
+        :param in_features:
+            See :py:class:`torch.nn.Linear`
+        :param out_features:
+            See :py:class:`torch.nn.Linear`
+        :param bias:
+            See :py:class:`torch.nn.Linear`
+        :param device:
+            See :py:class:`torch.nn.Linear`
+        :param dtype:
+            See :py:class:`torch.nn.Linear`
+        :param many_to_one:
+            Specifies if a separate module for each block is used. If True the module is
+            deepcopied for each key in the :py:attr:`in_keys`.
+        :param out_tensor:
+            A tensor map that is used to determine the properties labels of the output.
+            Because an arbitrary module can change the number of properties, the labels
+            of the properties cannot be persevered. By default the output properties are
+            relabeled using Labels.range.
+        """
+        module = torch.nn.Linear(in_features, out_features, bias, device, dtype)
+        return ModuleTensorMap.from_module(in_keys, module, many_to_one, out_tensor)
+
+    def forward(self, tensor: TensorMap) -> TensorMap:
+        # added to appear in doc, :inherited-members: is not compatible with torch
+        return super().forward(tensor)

--- a/src/equisolve/nn/module_tensor.py
+++ b/src/equisolve/nn/module_tensor.py
@@ -3,8 +3,7 @@ try:
 
     HAS_METATENSOR_TORCH = True
 except ImportError:
-    from metatensor import Labels, TensorBlock, TensorMap
-    from metatensor.core.labels import LabelsEntry
+    from metatensor import Labels, LabelsEntry, TensorBlock, TensorMap
 
     HAS_METATENSOR_TORCH = False
 

--- a/tests/equisolve_tests/nn/test_module_tensor.py
+++ b/tests/equisolve_tests/nn/test_module_tensor.py
@@ -1,7 +1,6 @@
-import functools
-
-import numpy as np
 import pytest
+
+from ..utilities import random_single_block_no_components_tensor_map
 
 
 try:
@@ -15,77 +14,13 @@ if HAS_TORCH:
     from equisolve.nn import Linear
 
 try:
-    from metatensor.torch import Labels, TensorBlock, TensorMap, allclose_raise
+    from metatensor.torch import allclose_raise
 
     HAS_METATENSOR_TORCH = True
 except ImportError:
-    from metatensor import Labels, TensorBlock, TensorMap, allclose_raise
+    from metatensor import allclose_raise
 
     HAS_METATENSOR_TORCH = False
-
-
-def random_single_block_no_components_tensor_map():
-    """
-    Create a dummy tensor map to be used in tests. This is the same one as the
-    tensor map used in `tensor.rs` tests.
-    """
-    if HAS_TORCH:
-        create_random_array = torch.rand
-    else:
-        create_random_array = np.random.rand
-
-    if HAS_METATENSOR_TORCH:
-        create_int32_array = functools.partial(torch.tensor, dtype=torch.int32)
-    else:
-        create_int32_array = functools.partial(np.array, dtype=np.int32)
-
-    block_1 = TensorBlock(
-        values=create_random_array(4, 2),
-        samples=Labels(
-            ["sample", "structure"],
-            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
-        ),
-        components=[],
-        properties=Labels(["properties"], create_int32_array([[0], [1]])),
-    )
-    positions_gradient = TensorBlock(
-        values=create_random_array(7, 3, 2),
-        samples=Labels(
-            ["sample", "structure", "center"],
-            create_int32_array(
-                [
-                    [0, 0, 1],
-                    [0, 0, 2],
-                    [1, 1, 0],
-                    [1, 1, 1],
-                    [1, 1, 2],
-                    [2, 2, 0],
-                    [3, 3, 0],
-                ],
-            ),
-        ),
-        components=[Labels(["direction"], create_int32_array([[0], [1], [2]]))],
-        properties=block_1.properties,
-    )
-    block_1.add_gradient("positions", positions_gradient)
-
-    cell_gradient = TensorBlock(
-        values=create_random_array(4, 6, 2),
-        samples=Labels(
-            ["sample", "structure"],
-            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
-        ),
-        components=[
-            Labels(
-                ["direction_xx_yy_zz_yz_xz_xy"],
-                create_int32_array([[0], [1], [2], [3], [4], [5]]),
-            )
-        ],
-        properties=block_1.properties,
-    )
-    block_1.add_gradient("cell", cell_gradient)
-
-    return TensorMap(Labels.single(), [block_1])
 
 
 @pytest.mark.skipif(not (HAS_TORCH), reason="requires torch to be run")
@@ -101,7 +36,9 @@ class TestModuleTensorMap:
     @pytest.mark.parametrize(
         "tensor",
         [
-            random_single_block_no_components_tensor_map(),
+            random_single_block_no_components_tensor_map(
+                HAS_TORCH, HAS_METATENSOR_TORCH
+            ),
         ],
     )
     def test_linear_module_init(self, tensor):
@@ -127,7 +64,9 @@ class TestModuleTensorMap:
     @pytest.mark.parametrize(
         "tensor",
         [
-            random_single_block_no_components_tensor_map(),
+            random_single_block_no_components_tensor_map(
+                HAS_TORCH, HAS_METATENSOR_TORCH
+            ),
         ],
     )
     def test_linear_module_from_module(self, tensor):
@@ -154,7 +93,9 @@ class TestModuleTensorMap:
     @pytest.mark.parametrize(
         "tensor",
         [
-            random_single_block_no_components_tensor_map(),
+            random_single_block_no_components_tensor_map(
+                HAS_TORCH, HAS_METATENSOR_TORCH
+            ),
         ],
     )
     @pytest.mark.skipif(

--- a/tests/equisolve_tests/nn/test_module_tensor.py
+++ b/tests/equisolve_tests/nn/test_module_tensor.py
@@ -1,0 +1,172 @@
+import functools
+
+import numpy as np
+import pytest
+
+
+try:
+    import torch
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+if HAS_TORCH:
+    from equisolve.nn import Linear
+
+try:
+    from metatensor.torch import Labels, TensorBlock, TensorMap, allclose_raise
+
+    HAS_METATENSOR_TORCH = True
+except ImportError:
+    from metatensor import Labels, TensorBlock, TensorMap, allclose_raise
+
+    HAS_METATENSOR_TORCH = False
+
+
+def random_single_block_no_components_tensor_map():
+    """
+    Create a dummy tensor map to be used in tests. This is the same one as the
+    tensor map used in `tensor.rs` tests.
+    """
+    if HAS_TORCH:
+        create_random_array = torch.rand
+    else:
+        create_random_array = np.random.rand
+
+    if HAS_METATENSOR_TORCH:
+        create_int32_array = functools.partial(torch.tensor, dtype=torch.int32)
+    else:
+        create_int32_array = functools.partial(np.array, dtype=np.int32)
+
+    block_1 = TensorBlock(
+        values=create_random_array(4, 2),
+        samples=Labels(
+            ["sample", "structure"],
+            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+        ),
+        components=[],
+        properties=Labels(["properties"], create_int32_array([[0], [1]])),
+    )
+    positions_gradient = TensorBlock(
+        values=create_random_array(7, 3, 2),
+        samples=Labels(
+            ["sample", "structure", "center"],
+            create_int32_array(
+                [
+                    [0, 0, 1],
+                    [0, 0, 2],
+                    [1, 1, 0],
+                    [1, 1, 1],
+                    [1, 1, 2],
+                    [2, 2, 0],
+                    [3, 3, 0],
+                ],
+            ),
+        ),
+        components=[Labels(["direction"], create_int32_array([[0], [1], [2]]))],
+        properties=block_1.properties,
+    )
+    block_1.add_gradient("positions", positions_gradient)
+
+    cell_gradient = TensorBlock(
+        values=create_random_array(4, 6, 2),
+        samples=Labels(
+            ["sample", "structure"],
+            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+        ),
+        components=[
+            Labels(
+                ["direction_xx_yy_zz_yz_xz_xy"],
+                create_int32_array([[0], [1], [2], [3], [4], [5]]),
+            )
+        ],
+        properties=block_1.properties,
+    )
+    block_1.add_gradient("cell", cell_gradient)
+
+    return TensorMap(Labels.single(), [block_1])
+
+
+@pytest.mark.skipif(not (HAS_TORCH), reason="requires torch to be run")
+class TestModuleTensorMap:
+    @pytest.fixture(autouse=True)
+    def set_random_generator(self):
+        """Set the random generator to same seed before each test is run.
+        Otherwise test behaviour is dependend on the order of the tests
+        in this file and the number of parameters of the test.
+        """
+        torch.random.manual_seed(122578741812)
+
+    @pytest.mark.parametrize(
+        "tensor",
+        [
+            random_single_block_no_components_tensor_map(),
+        ],
+    )
+    def test_linear_module_init(self, tensor):
+        tensor_module = Linear(tensor, tensor)
+        with torch.no_grad():
+            out_tensor = tensor_module(tensor)
+
+        for key, block in tensor.items():
+            module = tensor_module.module_map[Linear.module_key(key)]
+            with torch.no_grad():
+                ref_values = module(block.values)
+            out_block = out_tensor.block(key)
+            assert torch.allclose(ref_values, out_block.values)
+            assert block.properties == out_block.properties
+
+            for parameter, gradient in block.gradients():
+                with torch.no_grad():
+                    ref_gradient_values = module(gradient.values)
+                out_gradient = out_block.gradient(parameter)
+                assert torch.allclose(ref_gradient_values, out_gradient.values)
+                assert gradient.properties == out_gradient.properties
+
+    @pytest.mark.parametrize(
+        "tensor",
+        [
+            random_single_block_no_components_tensor_map(),
+        ],
+    )
+    def test_linear_module_from_module(self, tensor):
+        tensor_module = Linear.from_module(
+            tensor.keys, in_features=len(tensor[0].properties), out_features=5
+        )
+        with torch.no_grad():
+            out_tensor = tensor_module(tensor)
+
+        for key, block in tensor.items():
+            module = tensor_module.module_map[Linear.module_key(key)]
+            with torch.no_grad():
+                ref_values = module(block.values)
+            out_block = out_tensor.block(key)
+            assert torch.allclose(ref_values, out_block.values)
+
+            for parameter, gradient in block.gradients():
+                with torch.no_grad():
+                    ref_gradient_values = module(gradient.values)
+                assert torch.allclose(
+                    ref_gradient_values, out_block.gradient(parameter).values
+                )
+
+    @pytest.mark.parametrize(
+        "tensor",
+        [
+            random_single_block_no_components_tensor_map(),
+        ],
+    )
+    @pytest.mark.skipif(
+        not (HAS_METATENSOR_TORCH), reason="requires metatensor-torch to be run"
+    )
+    def test_torchscript_linear_module(self, tensor):
+        tensor_module = Linear.from_module(
+            tensor.keys, in_features=len(tensor[0].properties), out_features=5
+        )
+        ref_tensor = tensor_module(tensor)
+
+        tensor_module_script = torch.jit.script(tensor_module)
+        out_tensor = tensor_module_script(tensor)
+
+        allclose_raise(ref_tensor, out_tensor)

--- a/tests/equisolve_tests/numpy/utilities.py
+++ b/tests/equisolve_tests/numpy/utilities.py
@@ -1,61 +1,17 @@
+import functools
+
 import metatensor
 import numpy as np
-from metatensor import Labels, TensorBlock, TensorMap
+from metatensor import Labels, TensorMap
+
+from ..utilities import random_single_block_no_components_tensor_map
 
 
-def random_single_block_no_components_tensor_map():
-    """
-    Create a dummy tensor map to be used in tests. This is the same one as the
-    tensor map used in `tensor.rs` tests.
-    """
-    block_1 = TensorBlock(
-        values=np.random.rand(4, 2),
-        samples=Labels(
-            ["sample", "structure"],
-            np.array([[0, 0], [1, 1], [2, 2], [3, 3]], dtype=np.int32),
-        ),
-        components=[],
-        properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
-    )
-    positions_gradient = TensorBlock(
-        values=np.random.rand(7, 3, 2),
-        samples=Labels(
-            ["sample", "structure", "center"],
-            np.array(
-                [
-                    [0, 0, 1],
-                    [0, 0, 2],
-                    [1, 1, 0],
-                    [1, 1, 1],
-                    [1, 1, 2],
-                    [2, 2, 0],
-                    [3, 3, 0],
-                ],
-                dtype=np.int32,
-            ),
-        ),
-        components=[Labels(["direction"], np.array([[0], [1], [2]], dtype=np.int32))],
-        properties=block_1.properties,
-    )
-    block_1.add_gradient("positions", positions_gradient)
-
-    cell_gradient = TensorBlock(
-        values=np.random.rand(4, 6, 2),
-        samples=Labels(
-            ["sample", "structure"],
-            np.array([[0, 0], [1, 1], [2, 2], [3, 3]], dtype=np.int32),
-        ),
-        components=[
-            Labels(
-                ["direction_xx_yy_zz_yz_xz_xy"],
-                np.array([[0], [1], [2], [3], [4], [5]], dtype=np.int32),
-            )
-        ],
-        properties=block_1.properties,
-    )
-    block_1.add_gradient("cell", cell_gradient)
-
-    return TensorMap(Labels.single(), [block_1])
+random_single_block_no_components_tensor_map = functools.partial(
+    random_single_block_no_components_tensor_map,
+    use_torch=False,
+    use_metatensor_torch=False,
+)
 
 
 def tensor_to_tensormap(a: np.ndarray, key_name: str = "keys") -> TensorMap:

--- a/tests/equisolve_tests/utilities.py
+++ b/tests/equisolve_tests/utilities.py
@@ -1,0 +1,79 @@
+import functools
+
+
+def random_single_block_no_components_tensor_map(use_torch, use_metatensor_torch):
+    """
+    Create a dummy tensor map to be used in tests. This is the same one as the
+    tensor map used in `tensor.rs` tests.
+    """
+    if not use_torch and use_metatensor_torch:
+        raise ValueError(
+            "torch.TensorMap cannot be created without torch.Tensor block values."
+        )
+    if use_metatensor_torch:
+        import torch
+        from metatensor.torch import Labels, TensorBlock, TensorMap
+
+        create_int32_array = functools.partial(torch.tensor, dtype=torch.int32)
+    else:
+        import numpy as np
+        from metatensor import Labels, TensorBlock, TensorMap
+
+        create_int32_array = functools.partial(np.array, dtype=np.int32)
+
+    if use_torch:
+        import torch
+
+        create_random_array = torch.rand
+    else:
+        import numpy as np
+
+        create_random_array = np.random.rand
+
+    block_1 = TensorBlock(
+        values=create_random_array(4, 2),
+        samples=Labels(
+            ["sample", "structure"],
+            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+        ),
+        components=[],
+        properties=Labels(["properties"], create_int32_array([[0], [1]])),
+    )
+    positions_gradient = TensorBlock(
+        values=create_random_array(7, 3, 2),
+        samples=Labels(
+            ["sample", "structure", "center"],
+            create_int32_array(
+                [
+                    [0, 0, 1],
+                    [0, 0, 2],
+                    [1, 1, 0],
+                    [1, 1, 1],
+                    [1, 1, 2],
+                    [2, 2, 0],
+                    [3, 3, 0],
+                ],
+            ),
+        ),
+        components=[Labels(["direction"], create_int32_array([[0], [1], [2]]))],
+        properties=block_1.properties,
+    )
+    block_1.add_gradient("positions", positions_gradient)
+
+    cell_gradient = TensorBlock(
+        values=create_random_array(4, 6, 2),
+        samples=Labels(
+            ["sample", "structure"],
+            create_int32_array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+        ),
+        components=[
+            Labels(
+                ["direction_xx_yy_zz_yz_xz_xy"],
+                create_int32_array([[0], [1], [2], [3], [4], [5]]),
+            )
+        ],
+        properties=block_1.properties,
+    )
+    block_1.add_gradient("cell", cell_gradient)
+
+    return TensorMap(Labels.single(), [block_1])

--- a/tox.ini
+++ b/tox.ini
@@ -38,11 +38,9 @@ commands =
 setenv =
     PIP_EXTRA_INDEX_URL={env:PIP_EXTRA_INDEX_URL:https://download.pytorch.org/whl/cpu}
 usedevelop = {[testenv:core-numpy-tests]usedevelop}
+extras = torch
 deps =
     {[testenv:core-numpy-tests]deps}
-    # requires metatensor-torch version that is compatible with the metatensor-core
-    # version in the pyproject.toml
-    metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip
 commands =
     {[testenv:core-numpy-tests]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,9 @@ setenv =
 usedevelop = {[testenv:core-numpy-tests]usedevelop}
 deps =
     {[testenv:core-numpy-tests]deps}
-    metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/b17bc4d.zip
+    # requires metatensor-torch version that is compatible with the metatensor-core
+    # version in the pyproject.toml
+    metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/2248a3c.zip
 commands =
     {[testenv:core-numpy-tests]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,8 +70,11 @@ commands =
     isort {[tox]lint_folders}
 
 [testenv:docs]
-usedevelop = true
 # this environement builds the documentation with sphinx
+usedevelop = true
+setenv =
+    PIP_EXTRA_INDEX_URL={env:PIP_EXTRA_INDEX_URL:https://download.pytorch.org/whl/cpu}
+extras = torch
 deps =
     -r docs/requirements.txt
 commands = sphinx-build {posargs:-E} -W -b html docs/src docs/build/html

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,17 @@ ignore_basepython_conflict = true
 # these are the default environments, i.e. the list of tests running when you
 # execute `tox` in the command-line without anything else
 envlist =
-    tests
+    core-numpy-tests
+    core-torch-tests
+    torch-tests
     lint
 
 lint_folders = {toxinidir}/examples {toxinidir}/src {toxinidir}/tests
 
 [testenv]
 
-[testenv:tests]
-# this environement runs Python tests
+[testenv:core-numpy-tests]
+# this environement runs Python tests with core
 usedevelop = true
 deps =
     ase
@@ -19,6 +21,28 @@ deps =
 commands =
     pytest --import-mode=append {posargs}
 
+[testenv:core-torch-tests]
+# this environement runs Python tests only with metatensor-core
+usedevelop = {[testenv:core-numpy-tests]usedevelop}
+deps =
+    {[testenv:core-numpy-tests]deps}
+    torch
+commands =
+    {[testenv:core-numpy-tests]commands}
+
+[testenv:torch-tests]
+# this environement runs Python tests with metatensor-torch
+
+# we use by default the cpu version of torch, if the cuda version is desired
+# please overwrite the PIP_EXTRA_INDEX_URL
+setenv =
+    PIP_EXTRA_INDEX_URL={env:PIP_EXTRA_INDEX_URL:https://download.pytorch.org/whl/cpu}
+usedevelop = {[testenv:core-numpy-tests]usedevelop}
+deps =
+    {[testenv:core-numpy-tests]deps}
+    metatensor[torch] @ https://github.com/lab-cosmo/metatensor/archive/b17bc4d.zip
+commands =
+    {[testenv:core-numpy-tests]commands}
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
From the discussion in #13. Should replace https://github.com/bananenpampe/H2O/blob/move-rascaline/model/nn/modules.py

The goal is to offer a flexible wrapper class around torch modules that are applied on each block of a input TensorMap while also offer functions to wrap simpler cases, for example when the same module is used for all blocks (for that there is the `from_module` constructor).

What is missing, is a functionality that allows to merge multiple blocks into a new one (e.g. in species compression), but I also don't think it is a good idea to put this in the same class.

TODO (will add these after first review):
- [x] add another test for using the `__init__` of `Linear`
- [x] add another test for using the `from_module` of `ModuleTensorMap`
- [x] move `equisolve.nn` to `equisolve.torch.nn` (needs to be discussed in meeting) 
- [x] rascaline has been updated https://github.com/Luthaf/rascaline/pull/232 we can remove the requirements.txt (maybe keeping it is smarter because of cross linking of packages with sphinx, need to check this.)
----
:books: Documentation preview :books:: https://equisolve--62.org.readthedocs.build/en/62/

<!-- readthedocs-preview equisolve end -->