### PR TITLE
Fix float alpha in Ridge for generic samples

### DIFF
--- a/tests/equisolve_tests/numpy/models/linear_model.py
+++ b/tests/equisolve_tests/numpy/models/linear_model.py
@@ -468,16 +468,6 @@ class TestRidge:
         # TODO
         pass
 
-    def test_scalar_alpha(self):
-        """Test ridge regression with scalar alpha."""
-        # TODO
-        pass
-
-    def test_vector_alpha(self):
-        """Test ridge regression with a different alpha per property."""
-        # TODO
-        pass
-
     def test_sample_weights(self):
         """Test ridge regression with a different value per target property."""
         # TODO
@@ -492,6 +482,13 @@ class TestRidge:
         X = tensor_to_tensormap(X_arr)
         y = tensor_to_tensormap(y_arr)
         alpha = tensor_to_tensormap(alpha_arr)
+
+        # Slice TensorMaps to do not start at sample 0.
+        # Testing probable hardcoded sample
+        samples = Labels(names=X.samples_names, values=X[0].samples.values[1:])
+        kwargs = {"axis": "samples", "labels": samples}
+        X = metatensor.slice(X, **kwargs)
+        y = metatensor.slice(y, **kwargs)
 
         clf = Ridge()
 


### PR DESCRIPTION
If a `float` as alpha/regularizer is passed to the `Ridge` regressor we build a TensorMap with a single sample. This TensorMap allows us to use a single code path for the regression.

In the current implementation, however, we use `metatensor.slice` for using a hardcoded 0th for the TensorMap creation. The hardcoded slicing causes problems if there is no sample in the TensorMap with values that are all zero.

I fixed this bug by explicitly creating the TensorMap and adjusted the test to hopefully avoid this in the future.

<!-- readthedocs-preview equisolve start -->
----
:books: Documentation preview :books:: https://equisolve--66.org.readthedocs.build/en/66/

<!-- readthedocs-preview equisolve end -->